### PR TITLE
Add CniServer into HostDaemon

### DIFF
--- a/daemon/hostdaemon.go
+++ b/daemon/hostdaemon.go
@@ -2,11 +2,17 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
+	"time"
 
+	cni100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/go-logr/logr"
 	"github.com/openshift/dpu-operator/daemon/plugin"
+	"github.com/openshift/dpu-operator/dpu-cni/pkgs/cniserver"
 	"github.com/openshift/dpu-operator/dpu-cni/pkgs/cnitypes"
+	"github.com/openshift/dpu-operator/dpu-cni/pkgs/sriov"
 	pb "github.com/opiproject/opi-api/network/evpn-gw/v1alpha1/gen/go"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -22,17 +28,30 @@ type HostDaemon struct {
 	addr          string
 	port          int32
 	cniServerPath string
+	cniserver     *cniserver.Server
+	sm            sriov.Manager
 }
 
-func (d *HostDaemon) CreateBridgePort(pf int, vf int, vlan int) (*pb.BridgePort, error) {
-	d.connectWithRetry()
+func (d *HostDaemon) CreateBridgePort(pf int, vf int, vlan int, mac string) (*pb.BridgePort, error) {
+	err := d.connectWithRetry()
+	if err != nil {
+		return nil, err
+	}
+
+	m, err := net.ParseMAC(mac)
+	if err != nil {
+		return nil, err
+	}
+
 	createRequest := &pb.CreateBridgePortRequest{
 		BridgePort: &pb.BridgePort{
-			Name: fmt.Sprintf("%d-%d-%d", pf, vf, vlan),
+			Name: fmt.Sprintf("%d-%d", pf, vf),
 			Spec: &pb.BridgePortSpec{
-				Ptype:          1,
-				MacAddress:     []byte{},
-				LogicalBridges: []string{},
+				Ptype:      1,
+				MacAddress: m,
+				LogicalBridges: []string{
+					fmt.Sprintf("%d", vlan),
+				},
 			},
 		},
 	}
@@ -40,10 +59,10 @@ func (d *HostDaemon) CreateBridgePort(pf int, vf int, vlan int) (*pb.BridgePort,
 	return d.client.CreateBridgePort(context.TODO(), createRequest)
 }
 
-func (d *HostDaemon) DeleteBridgePort(pf int, vf int, vlan int) error {
+func (d *HostDaemon) DeleteBridgePort(pf int, vf int, vlan int, mac string) error {
 	d.connectWithRetry()
 	req := &pb.DeleteBridgePortRequest{
-		Name: fmt.Sprintf("%d-%d-%d", pf, vf, vlan),
+		Name: fmt.Sprintf("%d-%d-%d-%s", pf, vf, vlan, mac),
 	}
 
 	_, err := d.client.DeleteBridgePort(context.TODO(), req)
@@ -55,12 +74,23 @@ func NewHostDaemon(vsp plugin.VendorPlugin) *HostDaemon {
 		vsp:           vsp,
 		log:           ctrl.Log.WithName("HostDaemon"),
 		cniServerPath: cnitypes.ServerSocketPath,
+		sm:            sriov.NewSriovManager(),
 	}
 }
 
-func (d *HostDaemon) connectWithRetry() {
+func (d *HostDaemon) WithCniServerPath(serverPath string) *HostDaemon {
+	d.cniServerPath = serverPath
+	return d
+}
+
+func (d *HostDaemon) WithSriovManager(manager sriov.Manager) *HostDaemon {
+	d.sm = manager
+	return d
+}
+
+func (d *HostDaemon) connectWithRetry() error {
 	if d.conn != nil {
-		return
+		return nil
 	}
 	// Might want to change waitForReady to true to
 	// block on connection. Currently, we connect
@@ -82,13 +112,51 @@ func (d *HostDaemon) connectWithRetry() {
 	conn, err := grpc.Dial(fmt.Sprintf("%s:%d", d.addr, d.port), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultServiceConfig(retryPolicy))
 	if err != nil {
 		d.log.Error(err, "did not connect")
+		return err
 	}
 	d.conn = conn
 	d.client = pb.NewBridgePortServiceClient(conn)
+	return nil
 }
 
-func (d *HostDaemon) Start() {
-	d.log.Info("starting HostDaemon", "devflag", d.dev)
+func (d *HostDaemon) cniCmdAddHandler(req *cnitypes.PodRequest) (*cni100.Result, error) {
+	pf := 0
+	vf := req.CNIConf.VFID
+	mac := req.CNIConf.RuntimeConfig.Mac
+	d.log.Info("addHandler", "CNIConf", req.CNIConf)
+	vlan := *req.CNIConf.Vlan
+	d.log.Info("addHandler", "pf", pf, "vf", vf, "mac", mac, "vlan", vlan)
+	_, err := d.CreateBridgePort(pf, vf, vlan, mac)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to call CreateBridgePort: %v", err)
+	}
+	d.log.Info("addHandler CreateBridgePort succeeded")
+
+	res, err := d.sm.CmdAdd(req)
+	if err != nil {
+		return nil, errors.New("SRIOV manager failed in add handler")
+	}
+	d.log.Info("addHandler d.sm.CmdAdd succeeded")
+	return res, nil
+}
+
+func (d *HostDaemon) cniCmdDelHandler(req *cnitypes.PodRequest) (*cni100.Result, error) {
+	pf := 0
+	vf := req.CNIConf.VFID
+	mac := req.CNIConf.MAC
+	vlan := *req.CNIConf.Vlan
+	d.log.Info("delHandler", "pf", pf, "vf", vf, "mac", mac, "vlan", vlan)
+	d.DeleteBridgePort(pf, vf, vlan, mac)
+
+	err := d.sm.CmdDel(req)
+	if err != nil {
+		return nil, errors.New("SRIOV manager failed in del handler")
+	}
+	return nil, nil
+}
+
+func (d *HostDaemon) Listen() (net.Listener, error) {
+	d.log.Info("starting HostDaemon", "devflag", d.dev, "cniServerPath", d.cniServerPath)
 
 	addr, port, err := d.vsp.Start()
 	if err != nil {
@@ -96,4 +164,43 @@ func (d *HostDaemon) Start() {
 	}
 	d.addr = addr
 	d.port = port
+
+	add := func(r *cnitypes.PodRequest) (*cni100.Result, error) {
+		return d.cniCmdAddHandler(r)
+	}
+	del := func(r *cnitypes.PodRequest) (*cni100.Result, error) {
+		return d.cniCmdDelHandler(r)
+	}
+
+	d.cniserver = cniserver.NewCNIServer(add, del, cniserver.WithSocketPath(d.cniServerPath))
+
+	return d.cniserver.Listen()
+}
+
+func (d *HostDaemon) ListenAndServe() error {
+	listener, err := d.Listen()
+
+	if err != nil {
+		d.log.Error(err, "Failed to listen")
+		return err
+	}
+	return d.Serve(listener)
+}
+
+func (d *HostDaemon) Serve(listener net.Listener) error {
+	err := d.cniserver.Serve(listener)
+	if err != nil {
+		d.log.Error(err, "Error starting CNI server for shim")
+		return err
+	}
+	return nil
+}
+
+func (d *HostDaemon) Stop() {
+	if d.cniserver != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		defer cancel()
+		d.cniserver.Shutdown(ctx)
+		d.cniserver = nil
+	}
 }

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"net"
 	"os"
 
 	"github.com/openshift/dpu-operator/daemon/plugin"
@@ -16,7 +17,10 @@ import (
 var ()
 
 type Daemon interface {
-	Start()
+	Listen() (net.Listener, error)
+	ListenAndServe() error
+	Serve(listen net.Listener) error
+	Stop()
 }
 
 func isDpuMode(mode string) (bool, error) {
@@ -95,5 +99,5 @@ func main() {
 		log.Error(err, "Failed to start daemon")
 		return
 	}
-	daemon.Start()
+	daemon.ListenAndServe()
 }

--- a/daemon/main_test.go
+++ b/daemon/main_test.go
@@ -2,13 +2,21 @@ package main_test
 
 import (
 	"flag"
+	"os"
+	"path/filepath"
 
 	g "github.com/onsi/ginkgo/v2"
 	"go.uber.org/zap/zapcore"
+	"k8s.io/klog/v2"
 
 	. "github.com/onsi/gomega"
 
+	"github.com/containernetworking/cni/pkg/skel"
+	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/plugins/pkg/ns"
 	. "github.com/openshift/dpu-operator/daemon"
+	"github.com/openshift/dpu-operator/dpu-cni/pkgs/cni"
+	"github.com/openshift/dpu-operator/dpu-cni/pkgs/cnitypes"
 	opi "github.com/opiproject/opi-api/network/evpn-gw/v1alpha1/gen/go"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -38,6 +46,64 @@ func (v *DummyPlugin) DeleteBridgePort(deleteRequest *opi.DeleteBridgePortReques
 	return nil
 }
 
+type SriovManagerStub struct{}
+
+func (m SriovManagerStub) SetupVF(conf *cnitypes.NetConf, podifName string, netns ns.NetNS) error {
+	return nil
+}
+
+func (m SriovManagerStub) ReleaseVF(conf *cnitypes.NetConf, podifName string, netns ns.NetNS) error {
+	return nil
+}
+
+func (m SriovManagerStub) ResetVFConfig(conf *cnitypes.NetConf) error {
+	return nil
+}
+
+func (m SriovManagerStub) ApplyVFConfig(conf *cnitypes.NetConf) error {
+	return nil
+}
+
+func (m SriovManagerStub) FillOriginalVfInfo(conf *cnitypes.NetConf) error {
+	return nil
+}
+
+func (m SriovManagerStub) CmdAdd(req *cnitypes.PodRequest) (*current.Result, error) {
+	result := &current.Result{}
+	result.CNIVersion = req.CNIConf.CNIVersion
+	return result, nil
+}
+
+func (m SriovManagerStub) CmdDel(req *cnitypes.PodRequest) error {
+	return nil
+}
+
+func PrepArgs(cniVersion string, command string) *skel.CmdArgs {
+	cniConfig := "{\"cniVersion\": \"" + cniVersion + "\",\"name\": \"dpucni\",\"type\": \"dpucni\", \"RuntimeConfig\": {\"Mac\": \"00:11:22:33:44:55\"}, \"vlan\": 7}"
+	cmdArgs := &skel.CmdArgs{
+		ContainerID: "fakecontainerid",
+		Netns:       "fakenetns",
+		IfName:      "fakeeth0",
+		Args:        "",
+		Path:        "fakepath",
+		StdinData:   []byte(cniConfig),
+	}
+	os.Clearenv()
+	os.Setenv("CNI_COMMAND", command)
+	os.Setenv("CNI_ARGS", "K8S_POD_NAMESPACE=x;K8S_POD_NAME=y;K8S_POD_UID=z")
+	os.Setenv("CNI_CONTAINERID", cmdArgs.ContainerID)
+	os.Setenv("CNI_NETNS", cmdArgs.Netns)
+	os.Setenv("CNI_IFNAME", cmdArgs.IfName)
+	os.Setenv("CNI_PATH", cmdArgs.Path)
+
+	return cmdArgs
+}
+
+func cmdAdd(cniVersion string, serverSocketPath string) (*cnitypes.Response, string, error) {
+	p := &cni.Plugin{SocketPath: serverSocketPath}
+	return p.PostRequest(PrepArgs(cniVersion, cnitypes.CNIAdd))
+}
+
 var _ = g.BeforeSuite(func() {
 	opts := zap.Options{
 		Development: true,
@@ -49,18 +115,58 @@ var _ = g.BeforeSuite(func() {
 })
 
 var _ = g.Describe("Main", func() {
-	g.Context("Connection", func() {
+	var (
+		tmpDir           string
+		err              error
+		serverSocketPath string
+		dpuDaemon        *DpuDaemon
+		hostDaemon       *HostDaemon
+	)
+	g.BeforeEach(func() {
+		tmpDir, err = os.MkdirTemp("", "cniserver")
+		Expect(err).NotTo(HaveOccurred())
+		serverSocketPath = filepath.Join(tmpDir, "server.socket")
+
 		dummyPluginDPU := NewDummyPlugin()
-		DpuDaemon := NewDpuDaemon(dummyPluginDPU)
-
+		dpuDaemon = NewDpuDaemon(dummyPluginDPU)
 		dummyPluginHost := NewDummyPlugin()
-		HostDaemon := NewHostDaemon(dummyPluginHost)
+		m := SriovManagerStub{}
+		hostDaemon = NewHostDaemon(dummyPluginHost).
+			WithCniServerPath(serverSocketPath).
+			WithSriovManager(m)
+	})
 
-		g.It("Should connect succesfully if the server is up first", func() {
-			HostDaemon.Start()
-			DpuDaemon.Start()
-			_, err := HostDaemon.CreateBridgePort(1, 1, 1)
-			Expect(err).ShouldNot(HaveOccurred())
+	g.AfterEach(func() {
+		klog.Info("Cleaning up")
+		os.RemoveAll(tmpDir)
+		dpuDaemon.Stop()
+		hostDaemon.Stop()
+	})
+
+	g.Context("Host daemon", func() {
+		g.It("should respond to CNI calls", func() {
+			dpuListen, err := dpuDaemon.Listen()
+			Expect(err).NotTo(HaveOccurred())
+			go func() {
+				err = dpuDaemon.Serve(dpuListen)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			hostListen, err := hostDaemon.Listen()
+			Expect(err).NotTo(HaveOccurred())
+			go func() {
+				hostDaemon.Serve(hostListen)
+			}()
+
+			cniVersion := "0.4.0"
+			expectedResult := &current.Result{
+				CNIVersion: cniVersion,
+			}
+
+			resp, ver, err := cmdAdd(cniVersion, serverSocketPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ver).To(Equal(cniVersion))
+			Expect(resp.Result).To(Equal(expectedResult))
 		})
 	})
 })

--- a/daemon/plugin/vendorplugin.go
+++ b/daemon/plugin/vendorplugin.go
@@ -83,6 +83,7 @@ func (g *GrpcPlugin) CreateBridgePort(createRequest *opi.CreateBridgePortRequest
 	g.ensureConnected()
 	return g.opiClient.CreateBridgePort(context.TODO(), createRequest)
 }
+
 func (g *GrpcPlugin) DeleteBridgePort(deleteRequest *opi.DeleteBridgePortRequest) error {
 	g.ensureConnected()
 	_, err := g.opiClient.DeleteBridgePort(context.TODO(), deleteRequest)

--- a/dpu-cni/pkgs/cniserver/cniserver.go
+++ b/dpu-cni/pkgs/cniserver/cniserver.go
@@ -265,6 +265,7 @@ func (s *Server) handleCNIRequest(r *http.Request) ([]byte, error) {
 		result, err = s.cniCmdDelHandler(req)
 	}
 	if err != nil {
+		klog.Errorf("Error occured in handler: %v", err)
 		return nil, err
 	}
 

--- a/dpu-cni/pkgs/cniserver/cniserver_test.go
+++ b/dpu-cni/pkgs/cniserver/cniserver_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func PrepArgs(cniVersion string, command string) *skel.CmdArgs {
-	cniConfig := "{\"cniVersion\": \"" + cniVersion + "\",\"name\": \"dpucni\",\"type\": \"dpucni\"}"
+	cniConfig := "{\"cniVersion\": \"" + cniVersion + "\",\"name\": \"dpucni\",\"type\": \"dpucni\", \"Mac\": \"00:11:22:33:44:55\"}"
 	cmdArgs := &skel.CmdArgs{
 		ContainerID: "fakecontainerid",
 		Netns:       "fakenetns",

--- a/dpu-cni/pkgs/sriov/sriov.go
+++ b/dpu-cni/pkgs/sriov/sriov.go
@@ -64,7 +64,7 @@ type sriovManager struct {
 }
 
 // NewSriovManager returns an instance of SriovManager
-func NewSriovManager() Manager {
+func NewSriovManager() *sriovManager {
 	return &sriovManager{
 		nLink: &sriovutils.MyNetlink{},
 		utils: &pciUtilsImpl{},


### PR DESCRIPTION
This PR adds functionality to propagate a CNI add for a device that is added on the host down to the DPU which in turns forwards that to the vendor plugin on the DPU.