### PR TITLE
Fix daemon deployment from operator

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -22,6 +22,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 WORKDIR /
 COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/bindata /bindata
 USER 65532:65532
 
 RUN ls /

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) GOFLAGS='' go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) GOFLAGS='' go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.16
 
 .PHONY: operator-sdk
 OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk

--- a/bindata/daemon/02.daemon_role.yaml
+++ b/bindata/daemon/02.daemon_role.yaml
@@ -12,14 +12,3 @@ rules:
     - securitycontextconstraints
   verbs:
     - use
-- apiGroups:
-  - dpu.openshift.io
-  resources:
-  - dpus
-  verbs:
-  - watch
-  - create
-  - update
-  - patch
-  - list
-  - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,42 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - config.openshift.io
   resources:
   - dpuoperatorconfigs
@@ -30,3 +66,37 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - anyuid
+  - hostnetwork
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/dpu-cni/pkgs/cniserver/cniserver_test.go
+++ b/dpu-cni/pkgs/cniserver/cniserver_test.go
@@ -1,6 +1,7 @@
 package cniserver_test
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 
@@ -31,59 +32,72 @@ func processRequest(request *cnitypes.Request) (*current.Result, error) {
 		CNIVersion: conf.CNIVersion,
 	}
 
-	return result, nil
+    return result, nil
 }
 
 var _ = g.Describe("Cniserver", func() {
-	var tmpDir string
-	var plugin *cni.Plugin
+    var (
+        tmpDir        string
+        plugin        *cni.Plugin
+        cniServer     *cniserver.Server
+        serverSocketPath string
+        listener      net.Listener
+    )
 
-	var err error
-	// Create a tmp directory in the test container
-	tmpDir, err = utiltesting.MkTmpdir("cniserver")
-	defer os.RemoveAll(tmpDir)
-	o.Expect(err).NotTo(o.HaveOccurred())
-	serverSocketPath := filepath.Join(tmpDir, cnitypes.ServerSocketName)
-	cniServer := cniserver.NewCNIServer(
-		cniserver.WithHandler(processRequest),
-		cniserver.WithSocketPath(tmpDir, cnitypes.ServerSocketName))
-	listener, err := cniServer.Listen()
-	o.Expect(err).NotTo(o.HaveOccurred())
-	go utilwait.Forever(func() {
-		klog.Info("Starting to serve")
-		cniServer.Serve(listener)
-		klog.Info("done")
-	}, 0)
+    g.Context("CNI Server APIs", func() {
+        g.BeforeEach(func() {
+            var err error
+            // Create a tmp directory in the test container
+            tmpDir, err = utiltesting.MkTmpdir("cniserver")
+            o.Expect(err).NotTo(o.HaveOccurred())
+
+            serverSocketPath = filepath.Join(tmpDir, cnitypes.ServerSocketName)
+            cniServer = cniserver.NewCNIServer(
+                cniserver.WithHandler(processRequest),
+                cniserver.WithSocketPath(tmpDir, cnitypes.ServerSocketName))
+
+            listener, err = cniServer.Listen()
+            o.Expect(err).NotTo(o.HaveOccurred())
+
+            go utilwait.Forever(func() {
+                cniServer.Serve(listener)
+            }, 0)
+
+            plugin = &cni.Plugin{SocketPath: serverSocketPath}
+        })
+
+        g.AfterEach(func() {
+            listener.Close()
+            os.RemoveAll(tmpDir)
+        })
 
 
-	plugin = &cni.Plugin{SocketPath: serverSocketPath}
+        g.When("Normal ADD request", func() {
+            cniVersion := "0.4.0"
+            cniConfig := "{\"cniVersion\": \"" + cniVersion + "\",\"name\": \"dpucni\",\"type\": \"dpucni\"}"
+            cmdArgs := &skel.CmdArgs{
+                ContainerID: "fakecontainerid",
+                Netns:       "fakenetns",
+                IfName:      "fakeeth0",
+                Args:        "",
+                Path:        "fakepath",
+                StdinData:   []byte(cniConfig),
+            }
+            expectedResult := &current.Result{
+                CNIVersion: cniVersion,
+            }
+            os.Setenv("CNI_COMMAND", "ADD")
+            os.Setenv("CNI_CONTAINERID", cmdArgs.ContainerID)
+            os.Setenv("CNI_NETNS", cmdArgs.Netns)
+            os.Setenv("CNI_IFNAME", cmdArgs.IfName)
+            os.Setenv("CNI_PATH", cmdArgs.Path)
 
-	g.Context("CNI Server APIs", func() {
-		g.When("Normal ADD request", func() {
-			cniVersion := "0.4.0"
-			cniConfig := "{\"cniVersion\": \"" + cniVersion + "\",\"name\": \"dpucni\",\"type\": \"dpucni\"}"
-			cmdArgs := &skel.CmdArgs{
-				ContainerID: "fakecontainerid",
-				Netns:       "fakenetns",
-				IfName:      "fakeeth0",
-				Args:        "",
-				Path:        "fakepath",
-				StdinData:   []byte(cniConfig),
-			}
-			expectedResult := &current.Result{
-				CNIVersion: cniVersion,
-			}
-			os.Setenv("CNI_COMMAND", "ADD")
-			os.Setenv("CNI_CONTAINERID", cmdArgs.ContainerID)
-			os.Setenv("CNI_NETNS", cmdArgs.Netns)
-			os.Setenv("CNI_IFNAME", cmdArgs.IfName)
-			os.Setenv("CNI_PATH", cmdArgs.Path)
-			g.It("should get a correct response from the post request", func() {
-				resp, ver, err := plugin.PostRequest(cmdArgs)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				o.Expect(ver).To(o.Equal(cniVersion))
-				o.Expect(resp.Result).To(o.Equal(expectedResult))
-			})
-		})
-	})
+            g.It("should get a correct response from the post request", func() {
+                resp, ver, err := plugin.PostRequest(cmdArgs)
+                o.Expect(err).NotTo(o.HaveOccurred())
+                o.Expect(ver).To(o.Equal(cniVersion))
+                o.Expect(resp.Result).To(o.Equal(expectedResult))
+            })
+        })
+    })
 })

--- a/dpu-cni/pkgs/cniserver/cniserver_test.go
+++ b/dpu-cni/pkgs/cniserver/cniserver_test.go
@@ -46,10 +46,15 @@ var _ = g.Describe("Cniserver", func() {
 	serverSocketPath := filepath.Join(tmpDir, cnitypes.ServerSocketName)
 	cniServer := cniserver.NewCNIServer(
 		cniserver.WithHandler(processRequest),
-		cniserver.WithSocketPath(tmpDir, serverSocketPath))
+		cniserver.WithSocketPath(tmpDir, cnitypes.ServerSocketName))
+	listener, err := cniServer.Listen()
+	o.Expect(err).NotTo(o.HaveOccurred())
 	go utilwait.Forever(func() {
-		cniServer.Start()
+		klog.Info("Starting to serve")
+		cniServer.Serve(listener)
+		klog.Info("done")
 	}, 0)
+
 
 	plugin = &cni.Plugin{SocketPath: serverSocketPath}
 

--- a/internal/controller/dpuoperatorconfig_controller.go
+++ b/internal/controller/dpuoperatorconfig_controller.go
@@ -40,6 +40,12 @@ type DpuOperatorConfigReconciler struct {
 //+kubebuilder:rbac:groups=config.openshift.io,resources=dpuoperatorconfigs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=config.openshift.io,resources=dpuoperatorconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=dpuoperatorconfigs/finalizers,verbs=update
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=roles,resources=*,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=anyuid;hostnetwork;privileged,verbs=use
+//+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
Some of the RBAC permissions were not properly set, which precluded the daemonset from being created on a fresh cluster.

In addition, also fix the version of a tool used in the Makefile to avoid randomly breaking builds. 