### PR TITLE
Add image references for ART Team

### DIFF
--- a/bundle/manifests/dpu-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dpu-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-04-16T16:44:30Z"
+    createdAt: "2024-04-17T14:59:06Z"
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: dpu-operator.v4.16.0
@@ -211,8 +211,8 @@ spec:
                 - /manager
                 env:
                 - name: DPU_DAEMON_IMAGE
-                  value: quay.io/bnemeth/dpu-daemon
-                image: controller:latest
+                  value: quay.io/openshift/origin-dpu-operator-daemon:4.16
+                image: quay.io/openshift/origin-dpu-operator:4.16
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -72,8 +72,8 @@ spec:
         - --leader-elect
         env:
         - name: DPU_DAEMON_IMAGE
-          value: quay.io/bnemeth/dpu-daemon
-        image: controller:latest
+          value: quay.io/openshift/origin-dpu-operator-daemon:4.16
+        image: quay.io/openshift/origin-dpu-operator:4.16
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/stable/dpu-operator.clusterserviceversion.yaml
+++ b/manifests/stable/dpu-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-04-16T16:44:30Z"
+    createdAt: "2024-04-17T14:59:06Z"
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: dpu-operator.v4.16.0
@@ -211,8 +211,8 @@ spec:
                 - /manager
                 env:
                 - name: DPU_DAEMON_IMAGE
-                  value: quay.io/bnemeth/dpu-daemon
-                image: controller:latest
+                  value: quay.io/openshift/origin-dpu-operator-daemon:4.16
+                image: quay.io/openshift/origin-dpu-operator:4.16
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/manifests/stable/image-references
+++ b/manifests/stable/image-references
@@ -1,0 +1,17 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: dpu-operator
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-dpu-operator:4.16
+  - name: dpu-operator-daemon
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-dpu-operator-daemon:4.16
+  - name: kube-rbac-proxy
+    from:
+      kind: DockerImage
+      name: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1


### PR DESCRIPTION
Also replace any image references in our CSVs with "pretend" OKD images from quay.io. Please note that Red Hat isn't building OKD images as of writing.
    
Following: https://art-docs.engineering.redhat.com/olm-bundles/#image-references-and-specrelatedimages