### PR TITLE
Remove go mod download from dockerfile

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -6,10 +6,6 @@ ARG TARGETARCH
 WORKDIR /workspace
 COPY . .
 
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO


### PR DESCRIPTION
We are already vendoring this project. No need to run "go mod download"

Also the ART team builds in an air-gaped environment. Thus we cannot download anything.