### PR TITLE
Change the builder to RHEL9

### DIFF
--- a/Dockerfile.CNI.rhel
+++ b/Dockerfile.CNI.rhel
@@ -1,11 +1,13 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+ARG TARGETOS
+ARG TARGETARCH
 
 COPY . /usr/src/dpu-cni
 
 WORKDIR /usr/src/dpu-cni
 RUN go build -a -o dpucni ./dpu-cni/dpu-cni.go
 
-FROM registry.ci.openshift.org/ocp/4.15:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 COPY --from=builder /usr/src/dpu-cni/dpucni /usr/bin/
 WORKDIR /
 


### PR DESCRIPTION
The ART team has issues building with RHEL8. Thus we need to upgrade to RHEL9.