### PR TITLE
Allow users to set dev image tags from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,8 @@ CONTAINER_TOOL ?= podman
 
 # Use the image urls from the yaml that is used with Kustomize for local
 # development.
-DPU_OPERATOR_IMAGE := $(shell yq -r .spec.template.spec.containers[0].image config/dev/local-images.yaml)
-DPU_DAEMON_IMAGE := $(shell yq -r .spec.template.spec.containers[0].env[0].value config/dev/local-images.yaml)
+DPU_OPERATOR_IMAGE ?= $(shell yq -r .spec.template.spec.containers[0].image config/dev/local-images.yaml)
+DPU_DAEMON_IMAGE ?= $(shell yq -r .spec.template.spec.containers[0].env[0].value config/dev/local-images.yaml)
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.


### PR DESCRIPTION
It can be tedious modifying config/dev/local-images or having to apply local changes to build.

Allow users to just do:
DPU_OPERATOR_IMAGE="my-image" && make local-build