### PR TITLE
Fix DPU CNI binary copy regression

### DIFF
--- a/daemon/main.go
+++ b/daemon/main.go
@@ -111,12 +111,12 @@ func main() {
 	err = prepareCni("/var/lib/cni/bin/dpu-cni")
 	if err != nil {
 		log.Error(err, "Failed to prepare CNI binary in /var/lib")
-		return
+		/* Don't return on error for now */
 	}
 	err = prepareCni("/opt/cni/bin/dpu-cni")
 	if err != nil {
 		log.Error(err, "Failed to prepare CNI binary in /opt")
-		return
+		/* Don't return on error for now */
 	}
 
 	dpuMode, err = isDpuMode(mode)


### PR DESCRIPTION
Due to: https://github.com/bn222/dpu-operator/blame/a1ff551f544c1705dfdb18cb67a093124640cfa9/daemon/main.go#L119
From commit: "35ebd23" Add SFC reconciler to daemon