### PR TITLE
Set seccompProfile in operator replicaset

### DIFF
--- a/bundle/manifests/dpu-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dpu-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-06-28T09:19:35Z"
+    createdAt: "2024-07-01T18:55:02Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
     features.operators.openshift.io/csi: "false"
@@ -103,6 +103,12 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
         - apiGroups:
           - apps
           resources:
@@ -179,6 +185,21 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
@@ -310,6 +331,8 @@ spec:
                     - ALL
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: dpu-operator-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,8 +63,8 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         # Please uncomment the following code if your project does NOT have to work on old Kubernetes
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager

--- a/manifests/stable/dpu-operator.clusterserviceversion.yaml
+++ b/manifests/stable/dpu-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-06-28T09:19:35Z"
+    createdAt: "2024-07-01T18:55:02Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
     features.operators.openshift.io/csi: "false"
@@ -103,6 +103,12 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
         - apiGroups:
           - apps
           resources:
@@ -179,6 +185,21 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
@@ -310,6 +331,8 @@ spec:
                     - ALL
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: dpu-operator-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:


### PR DESCRIPTION
We need to specify the seccompProfile. Without this, the replicaset fails to start via "make local-deploy"  with the following error:

Warning  FailedCreate  35s (x5 over 73s)  replicaset-controller  (combined from similar events): Error creating: pods "dpu-operator-controller-manager-5f95b6c647-bkf85" is forbidden: violates PodSecurity "restricted:latest": seccompProfile (pod or containers "manager", "kube-rbac-proxy" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")