### PR TITLE
Fix clusterrole

### DIFF
--- a/bundle/manifests/dpu-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dpu-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-07-01T18:55:02Z"
+    createdAt: "2024-07-08T20:52:39Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
     features.operators.openshift.io/csi: "false"
@@ -200,6 +200,7 @@ spec:
           - clusterroles
           verbs:
           - create
+          - get
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -125,6 +125,7 @@ rules:
   - clusterroles
   verbs:
   - create
+  - get
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/internal/controller/dpuoperatorconfig_controller.go
+++ b/internal/controller/dpuoperatorconfig_controller.go
@@ -72,7 +72,7 @@ func (r *DpuOperatorConfigReconciler) WithImagePullPolicy(policy string) *DpuOpe
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=anyuid;hostnetwork;privileged,verbs=use
 //+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create;get
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create
 

--- a/manifests/stable/dpu-operator.clusterserviceversion.yaml
+++ b/manifests/stable/dpu-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-07-01T18:55:02Z"
+    createdAt: "2024-07-08T20:52:39Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
     features.operators.openshift.io/csi: "false"
@@ -200,6 +200,7 @@ spec:
           - clusterroles
           verbs:
           - create
+          - get
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:


### PR DESCRIPTION
This is required when ensuring the daemon is running.

Without this role, we will hit the following error:

2024-07-08T19:55:23Z    ERROR   Reconciler error        {"controller":
"dpuoperatorconfig", "controllerGroup": "config.openshift.io",
"controllerKind": "DpuOperatorConfig", "DpuOperatorConfig":
{"name":"dpu-operator-config"}, "namespace": "", "name": "dpu-operato
r-config", "reconcileID": "8ff59f4b-9f68-4dc6-b859-8dfb59ec9acc",
"error": "failed to apply object
&{map[apiVersion:rbac.authorization.k8s.io/v1 kind:ClusterRole
metadata:map[name:dpu-daemon-cluster-role
ownerReferences:[map[apiVersion:config.openshift.io/v1 bloc
kOwnerDeletion:true controller:true kind:DpuOperatorConfig
name:dpu-operator-config uid:dfba8a8b-23f6-4848-8a96-85aac4a5b0d6]]]
rules:[map[apiGroups:[apiextensions.k8s.io]
resources:[customresourcedefinitions] verbs:[get]]]]} with err: could
not retrieve existing
 (rbac.authorization.k8s.io/v1, Kind=ClusterRole)
/dpu-daemon-cluster-role: clusterroles.rbac.authorization.k8s.io
\"dpu-daemon-cluster-role\" is forbidden: User
\"system:serviceaccount:openshift-dpu-operator:dpu-operator-controller-manager\"
cannot get resource
\"clusterroles\" in API group \"rbac.authorization.k8s.io\" at the
cluster scope"}