### PR TITLE
add required labels to dpu operator ns

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -9,6 +9,9 @@ metadata:
     app.kubernetes.io/created-by: dpu-operator
     app.kubernetes.io/part-of: dpu-operator
     app.kubernetes.io/managed-by: kustomize
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: system
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
When deploying the dpu daemon daemonset via make local-deploy the daemonset pods fail to come up due to the level of privlege required by the pods.

i.e.
securityContext.privileged=true
allowPrivilegeEscalation!=false
hostNetwork=true
hostPID=true
volumes "devicesock", "dpu-daemon-mount", "var-cni-dir", "opt-cni-dir", "host-run", "proc" use restricted volume type "hostPath" ! securityContext.capabilities.drop=["ALL"]
securityContext.seccompProfile.type!="RuntimeDefault" or "Localhost"

We can fix this by expanding the privileges of the dpu operator namespace to match what is required by the daemon