### PR TITLE
Clean up local build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ local-buildx: ## Build all container images necessary to run the whole operator
 	buildah build --authfile /root/config.json --manifest $(DPU_DAEMON_IMAGE)-manifest --platform linux/amd64,linux/arm64 -v $(GO_CONTAINER_CACHE):/go:z -f Dockerfile.daemon.rhel -t $(DPU_DAEMON_IMAGE)
 
 .PHONY: local-pushx
-local-pushx: ## Push all container images necessary to run the whole operator
+local-pushx: local-buildx ## Push all container images necessary to run the whole operator
 	buildah manifest push --all $(DPU_OPERATOR_IMAGE)-manifest docker://$(DPU_OPERATOR_IMAGE)
 	buildah manifest push --all $(DPU_DAEMON_IMAGE)-manifest docker://$(DPU_DAEMON_IMAGE)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,32 @@ This operator will manage and configure data processing unit (DPUs) to be used i
 You’ll need a Kubernetes cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) to get a local cluster for testing, or run against a remote cluster.
 **Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever cluster `kubectl cluster-info` shows).
 
+### Building and testing against a local cluster
+If you want to start from the source, follow the steps below to build containers, push them to a local registry, and deploying to a cluster.
+
+1. Configure and Build Containers
+
+Run the following command to configure and build all the containers:
+```sh
+make local-buildx
+```
+2. Push Built Images to a Local Registry
+
+Run the following command to push the built images to a local registry:
+```sh
+make local-pushx
+```
+3. Deploy to the Cluster
+
+Run the following command to deploy the YAML files to the cluster based on `KUBECONFIG`:
+```sh
+make local-deploy
+```
+
+4. To deploy from a different registry, define the `REGISTERY` variable:
+
+`make local-deploy REGISTERY=...`
+
 ### Running on the cluster
 1. Install Instances of Custom Resources:
 

--- a/config/dev/kustomization.yaml
+++ b/config/dev/kustomization.yaml
@@ -1,4 +1,4 @@
 resources:
-- ../default
+- ../config/default
 patchesStrategicMerge:
 - local-images.yaml

--- a/config/dev/local-images-template.yaml
+++ b/config/dev/local-images-template.yaml
@@ -19,8 +19,8 @@ spec:
         name: manager
         env:
         - name: DPU_DAEMON_IMAGE
-          value: localhost:5000/dpu-daemon:dev
+          value: {{ .RegistryURL }}:5000/dpu-daemon:dev
         - name: IMAGE_PULL_POLICIES
           value: Always
-        image: localhost:5000/dpu-operator:dev
+        image: {{ .RegistryURL }}:5000/dpu-operator:dev
         imagePullPolicy: Always

--- a/tools/config.go
+++ b/tools/config.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"text/template"
+)
+
+var (
+	registryURL  string
+	templateFile string
+	outputFile   string
+)
+
+func applyTemplate(registryURL string, templateBytes []byte) ([]byte, error) {
+	templateData := struct {
+		RegistryURL string
+	}{
+		RegistryURL: registryURL,
+	}
+
+	t, err := template.New("example").Parse(string(templateBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	var output bytes.Buffer
+	err = t.Execute(&output, templateData)
+	if err != nil {
+		return nil, err
+	}
+
+	return output.Bytes(), nil
+}
+
+func main() {
+	flag.StringVar(&registryURL, "registry-url", "", "Registry URL")
+	flag.StringVar(&templateFile, "template-file", "", "Input template file")
+	flag.StringVar(&outputFile, "output-file", "", "Output YAML file")
+	flag.Parse()
+
+	if registryURL == "" || templateFile == "" || outputFile == "" {
+		fmt.Println("Usage: -registry-url <url> -template-file <file> -output-file <file>")
+		return
+	}
+
+	templateBytes, err := os.ReadFile(templateFile)
+	if err != nil {
+		panic(err)
+	}
+
+	outputBytes, err := applyTemplate(registryURL, templateBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	err = os.WriteFile(outputFile, outputBytes, 0644)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,0 +1,3 @@
+module github.com/openshift/dpu-operator/tools
+
+go 1.22.4


### PR DESCRIPTION
This allows to build locally without having to manually change a file. This PR adds a tool that will write a kustomize config with the right arguments defined in the Makefile.

Also, clean up the targets and docs.