### PR TITLE
Fix bug in DPU Platform Info

### DIFF
--- a/cmd/daemon/daemon.go
+++ b/cmd/daemon/daemon.go
@@ -41,7 +41,7 @@ func isDpuMode(log logr.Logger, mode string) (bool, error) {
 	} else if mode == "dpu" {
 		return true, nil
 	} else if mode == "auto" {
-		platform := platform.PlatformInfo{}
+		platform := platform.NewPlatformInfo()
 		detectedDpuMode, err := platform.IsDpu()
 		if err != nil {
 			return false, fmt.Errorf("Failed to query platform info: %v", err)
@@ -54,7 +54,7 @@ func isDpuMode(log logr.Logger, mode string) (bool, error) {
 }
 
 func createDaemon(dpuMode bool, config *rest.Config) (Daemon, error) {
-	platform := platform.PlatformInfo{}
+	platform := platform.NewPlatformInfo()
 	plugin, err := platform.VspPlugin(dpuMode)
 	if err != nil {
 		return nil, err

--- a/internal/platform/ipu.go
+++ b/internal/platform/ipu.go
@@ -17,7 +17,7 @@ func NewIntelDetector() *IntelDetector {
 }
 
 func (d *IntelDetector) IsDPU(pci ghw.PCIDevice) bool {
-	return pci.Class.Name == "Ethernet controller" &&
+	return pci.Class.Name == "Network controller" &&
 		pci.Vendor.Name == "Intel Corporation" &&
 		pci.Product.Name == "Infrastructure Data Path Function"
 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -49,9 +49,6 @@ func (pi *PlatformInfo) listDpuDevices() ([]ghw.PCIDevice, []VendorDetector, err
 		return nil, nil, errors.Errorf("Error getting PCI info: %v", err)
 	}
 
-	if err != nil {
-		return nil, nil, err
-	}
 	var dpuDevices []ghw.PCIDevice
 	var activeDetectors []VendorDetector
 	for _, pci := range pci.ListDevices() {
@@ -77,9 +74,7 @@ func (pi *PlatformInfo) VspPlugin(dpuMode bool) (*plugin.GrpcPlugin, error) {
 		if len(dpuDevices) == 0 {
 			return nil, fmt.Errorf("Failed to detect any DPU devices")
 		}
-		if len(dpuDevices) != 1 {
-			return nil, fmt.Errorf("%v DPU devices detected. Currently only supporting exactly 1 DPU per node", len(dpuDevices))
-		}
+		// FIXME: We need to find a good way to determine VF from PF with the Intel DPU versus different DPU vendors.
 		return detectors[0].VspPlugin(dpuMode), nil
 	}
 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -2,6 +2,8 @@ package platform
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/jaypipes/ghw"
 	"github.com/openshift/dpu-operator/internal/daemon/plugin"
@@ -63,6 +65,18 @@ func (pi *PlatformInfo) listDpuDevices() ([]ghw.PCIDevice, []VendorDetector, err
 	return dpuDevices, activeDetectors, nil
 }
 
+func isVirtualFunction(device string) (bool, error) {
+	physfnPath := filepath.Join("/sys/bus/pci/devices", device, "physfn")
+
+	if _, err := os.Stat(physfnPath); err == nil {
+		return true, nil
+	} else if os.IsNotExist(err) {
+		return false, nil
+	} else {
+		return false, fmt.Errorf("Error when stating path %s: %v", device, err)
+	}
+}
+
 func (pi *PlatformInfo) VspPlugin(dpuMode bool) (*plugin.GrpcPlugin, error) {
 	if dpuMode {
 		return plugin.NewGrpcPlugin(dpuMode), nil
@@ -74,7 +88,25 @@ func (pi *PlatformInfo) VspPlugin(dpuMode bool) (*plugin.GrpcPlugin, error) {
 		if len(dpuDevices) == 0 {
 			return nil, fmt.Errorf("Failed to detect any DPU devices")
 		}
-		// FIXME: We need to find a good way to determine VF from PF with the Intel DPU versus different DPU vendors.
-		return detectors[0].VspPlugin(dpuMode), nil
+
+		var pfDevices []*ghw.PCIDevice
+		var pfDetectors []VendorDetector
+
+		for i, device := range dpuDevices {
+			isVF, err := isVirtualFunction(device.Address)
+			if err != nil {
+				return nil, fmt.Errorf("Error determining if device %s is a VF or PF: %v", device.Address, err)
+			}
+			if !isVF {
+				pfDevices = append(pfDevices, &device)
+				pfDetectors = append(pfDetectors, detectors[i])
+			}
+		}
+
+		if len(pfDevices) != 1 {
+			return nil, fmt.Errorf("%v DPU devices detected. Currently only supporting exactly 1 DPU per node", len(pfDevices))
+		}
+
+		return pfDetectors[0].VspPlugin(dpuMode), nil
 	}
 }


### PR DESCRIPTION
We need to create a new instance of the PlatformInfo struct to ensure the NewIntelDetector is added.

Additionally, fix a small bug in determining a device is an Intel DPU. The Intel IPU pci Class/Vendor/Product should be:

Network controller Intel Corporation Infrastructure Data Path Function