### PR TITLE
NO-JIRA: fix image references in 4.18

### DIFF
--- a/manifests/stable/dpu-operator.clusterserviceversion.yaml
+++ b/manifests/stable/dpu-operator.clusterserviceversion.yaml
@@ -52,7 +52,7 @@ metadata:
     operatorframework.io/suggested-namespace: openshift-dpu-operator
     operators.operatorframework.io/builder: operator-sdk-v1.34.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: dpu-operator.v4.16.0
+  name: dpu-operator.v4.18.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}

--- a/manifests/stable/image-references
+++ b/manifests/stable/image-references
@@ -6,11 +6,11 @@ spec:
   - name: dpu-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-dpu-operator:4.16
+      name: quay.io/openshift/origin-dpu-operator:4.18
   - name: dpu-daemon
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-dpu-daemon:4.16
+      name: quay.io/openshift/origin-dpu-daemon:4.18
   - name: kube-rbac-proxy
     from:
       kind: DockerImage


### PR DESCRIPTION
Fix incorrect image references in `release-4.18`

Please verify and follow up if other places need to be modified as well.