### PR TITLE
CDA: hardcode current iso

### DIFF
--- a/cluster_configs/config-dpu.yaml
+++ b/cluster_configs/config-dpu.yaml
@@ -4,7 +4,7 @@ clusters:
     ingress_vip: "192.168.122.101"
     network_api_port: "eno12409"
     kind: "iso"
-    install_iso: "{{iso()}}"
+    install_iso: "{{iso_server()}}/RHEL-9.4.0-20240514.71-aarch64-dvd1-w-kickstart.iso"
     masters:
     - name: "{{worker_number(0)}}-acc"
       node: "localhost"


### PR DESCRIPTION
Previously testing would call out to CDA to determine the iso to install with.

Instead, define this in dpu operator so we can track updates / validate when we move to newer versions.

TODO: Instead of using a "pre-built" iso, we should eventually strive to automatically create the iso from the latest nightly.