### PR TITLE
[th/makefile-default] Makefile: add default target that does a local build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,9 @@ PREPARE_SCRIPT = hack/prepare.sh
 IPU_HOST_SCRIPT = hack/ipu_host_deploy.sh
 IPU_DEPLOY_SCRIPT = hack/ipu_deploy.sh
 
+.PHONY: default
+default: build
+
 .PHONY: prepare
 prepare:
 	bash $(PREPARE_SCRIPT)


### PR DESCRIPTION
With make, when typing `make` without specifying a target, the first target will run. Currently that is `prepare` target which runs `hack/prepare.sh`.

That prepare script, among others, tries to restart libvird service (which requires root). It does not seem something that should be done by default (or regularly).

Instead, the default target should do something that does not require root and is somewhat useful. Doing a local build seems to be that.

Add a "default" target, which is also the first target in the Makefile and thus the default. That invokes the "build" target.

This makes a plain `make` doing something more(?) useful.