### PR TITLE
[th/vendor-plugin-deploy] various fixes for starting the Marvell VSP on the DPU

### DIFF
--- a/cmd/daemon/daemon.go
+++ b/cmd/daemon/daemon.go
@@ -54,17 +54,6 @@ func isDpuMode(log logr.Logger, mode string) (bool, error) {
 	}
 }
 
-func getVspImagesFromEnv() map[string]string {
-	vspImages := make(map[string]string)
-
-	for _, vspImageName := range plugin.VspImages {
-		value := os.Getenv(vspImageName)
-		vspImages[vspImageName] = value
-	}
-
-	return vspImages
-}
-
 func createDaemon(dpuMode bool, config *rest.Config, vspImages map[string]string, client client.Client) (Daemon, error) {
 	platform := platform.NewPlatformInfo()
 	plugin, err := platform.VspPlugin(dpuMode, vspImages, client)
@@ -172,7 +161,7 @@ func main() {
 		log.Error(err, "Failed to parse mode")
 		return
 	}
-	vspImages := getVspImagesFromEnv()
+	vspImages := plugin.CreateVspImagesMap(true, log)
 	daemon, err := createDaemon(dpuMode, config, vspImages, client)
 	if err != nil {
 		log.Error(err, "Failed to start daemon")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -96,15 +96,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	vspImages := make(map[string]string)
-
-	for _, vspImageName := range plugin.VspImages {
-		value := os.Getenv(vspImageName)
-		if value == "" {
-			setupLog.Info("VspImage env var not set", "VspImage", vspImageName)
-		}
-		vspImages[vspImageName] = value
-	}
+	vspImages := plugin.CreateVspImagesMap(true, setupLog)
 
 	dpuDaemonImage := os.Getenv("DPU_DAEMON_IMAGE")
 	if dpuDaemonImage == "" {

--- a/config/dev/local-images-template.yaml
+++ b/config/dev/local-images-template.yaml
@@ -22,6 +22,8 @@ spec:
           value: {{ .RegistryURL }}:5000/dpu-daemon:dev
         - name: IntelVspImage
           value: {{ .RegistryURL }}:5000/intel_vsp:dev
+        - name: MarvellVspImage
+          value: {{ .RegistryURL }}:5000/mrvl-vsp:dev
         - name: IMAGE_PULL_POLICIES
           value: Always
         image: {{ .RegistryURL }}:5000/dpu-operator:dev

--- a/internal/controller/bindata/daemon/99.daemonset.yaml
+++ b/internal/controller/bindata/daemon/99.daemonset.yaml
@@ -36,6 +36,8 @@ spec:
           value: {{.Namespace}}
         - name: IntelVspImage
           value: {{.IntelVspImage}}
+        - name: MarvellVspImage
+          value: {{.MarvellVspImage}}
         volumeMounts:
         - name: devicesock
           mountPath: /var/lib/kubelet/

--- a/internal/controller/dpuoperatorconfig_controller_test.go
+++ b/internal/controller/dpuoperatorconfig_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/openshift/dpu-operator/internal/daemon/plugin"
 	"github.com/openshift/dpu-operator/internal/testutils"
 
 	configv1 "github.com/openshift/dpu-operator/api/v1"
@@ -129,7 +130,7 @@ func startDPUControllerManager(ctx context.Context, client *rest.Config, wg *syn
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	b := NewDpuOperatorConfigReconciler(mgr.GetClient(), mgr.GetScheme(), "mock-image", map[string]string{"IntelVspImage": ""})
+	b := NewDpuOperatorConfigReconciler(mgr.GetClient(), mgr.GetScheme(), "mock-image", plugin.CreateVspImagesMap(false, setupLog))
 	err = b.SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/internal/daemon/plugin/bindata/vsp-ds/99.vendor-plugin-daemonset.yaml
+++ b/internal/daemon/plugin/bindata/vsp-ds/99.vendor-plugin-daemonset.yaml
@@ -22,9 +22,8 @@ spec:
         imagePullPolicy: {{.ImagePullPolicy}}
         securityContext:
           privileged: true
-        #TODO: These should be passed as arguments based on the particular vsp being deployed or automatically build into the image
-        command: [ "/usr/bin/ipuplugin" ]
-        args: [ "--bridgeType=linux", "--interface=enp0s1f0d3", "--portMuxVsi=0x0e", "--ovsCliDir=/opt/p4/p4-cp-nws", "-v=debug"]
+        command: {{.Command}}
+        args: {{.Args}}
         volumeMounts:
         - name: vendor-plugin-sock
           mountPath: /var/run/dpu-daemon/

--- a/internal/daemon/plugin/vendorplugin.go
+++ b/internal/daemon/plugin/vendorplugin.go
@@ -72,6 +72,8 @@ func CreateVspImageVars(vspImage string) map[string]string {
 		"Namespace":                 "openshift-dpu-operator",
 		"ImagePullPolicy":           "Always",
 		"VendorSpecificPluginImage": vspImage,
+		"Command":                   "[ ]",
+		"Args":                      "[ ]",
 	}
 }
 

--- a/internal/daemon/plugin/vendorplugin.go
+++ b/internal/daemon/plugin/vendorplugin.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"fmt"
 	"net"
+	"os"
 
 	"github.com/go-logr/logr"
 	pb "github.com/openshift/dpu-operator/dpu-api/gen"
@@ -24,6 +25,24 @@ var VspImages = []string{
 	"IntelVspImage",
 	"MarvellVspImage",
 	// TODO: Add future supported vendor plugins here
+}
+
+func CreateVspImagesMap(fromEnv bool, logger logr.Logger) map[string]string {
+	vspImages := make(map[string]string)
+
+	for _, vspImageName := range VspImages {
+		var value string
+
+		if fromEnv {
+			value = os.Getenv(vspImageName)
+			if value == "" {
+				logger.Info("VspImage env var not set", "VspImage", vspImageName)
+			}
+		}
+		vspImages[vspImageName] = value
+	}
+
+	return vspImages
 }
 
 type VendorPlugin interface {

--- a/internal/daemon/plugin/vendorplugin.go
+++ b/internal/daemon/plugin/vendorplugin.go
@@ -66,15 +66,13 @@ type GrpcPlugin struct {
 	pathManager utils.PathManager
 }
 
-func (g *GrpcPlugin) createCommonData(vspImage string) map[string]string {
+func CreateVspImageVars(vspImage string) map[string]string {
 	// All the CRs will be in the same namespace as the operator config
-	data := map[string]string{
+	return map[string]string{
 		"Namespace":                 "openshift-dpu-operator",
 		"ImagePullPolicy":           "Always",
 		"VendorSpecificPluginImage": vspImage,
 	}
-
-	return data
 }
 
 func (g *GrpcPlugin) Start() (string, int32, error) {
@@ -101,13 +99,12 @@ func WithPathManager(pathManager utils.PathManager) func(*GrpcPlugin) {
 	}
 }
 
-func WithVspImage(vspImage string) func(*GrpcPlugin) {
+func WithVspImage(template_vars map[string]string) func(*GrpcPlugin) {
 	return func(d *GrpcPlugin) {
+		vspImage := template_vars["VendorSpecificPluginImage"]
 		d.vspImage = vspImage
 		d.log.Info("VSP Image", "vspImage", d.vspImage)
-		data := d.createCommonData(d.vspImage)
-
-		err := render.ApplyAllFromBinData(d.log, "vsp-ds", data, binData, d.k8sClient, nil, nil)
+		err := render.ApplyAllFromBinData(d.log, "vsp-ds", template_vars, binData, d.k8sClient, nil, nil)
 		if err != nil {
 			d.log.Error(err, "Failed to start vendor plugin container", "vspImage", d.vspImage)
 		}

--- a/internal/platform/ipu.go
+++ b/internal/platform/ipu.go
@@ -58,8 +58,8 @@ func (pi *IntelDetector) IsDpuPlatform() (bool, error) {
 }
 
 func (pi *IntelDetector) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client) *plugin.GrpcPlugin {
-	intelVspImage := vspImages["IntelVspImage"]
-	return plugin.NewGrpcPlugin(dpuMode, client, plugin.WithVspImage(intelVspImage))
+	template_vars := plugin.CreateVspImageVars(vspImages["IntelVspImage"])
+	return plugin.NewGrpcPlugin(dpuMode, client, plugin.WithVspImage(template_vars))
 }
 
 func (d *IntelDetector) GetVendorName() string {

--- a/internal/platform/ipu.go
+++ b/internal/platform/ipu.go
@@ -59,6 +59,8 @@ func (pi *IntelDetector) IsDpuPlatform() (bool, error) {
 
 func (pi *IntelDetector) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client) *plugin.GrpcPlugin {
 	template_vars := plugin.CreateVspImageVars(vspImages["IntelVspImage"])
+	template_vars["Command"] = `[ "/usr/bin/ipuplugin" ]`
+	template_vars["Args"] = `[ "-v=debug" ]`
 	return plugin.NewGrpcPlugin(dpuMode, client, plugin.WithVspImage(template_vars))
 }
 

--- a/internal/platform/marvell-dpu.go
+++ b/internal/platform/marvell-dpu.go
@@ -53,6 +53,7 @@ func (pi *MarvellDetector) IsDpuPlatform() (bool, error) {
 
 func (pi *MarvellDetector) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client) *plugin.GrpcPlugin {
 	template_vars := plugin.CreateVspImageVars(vspImages["MarvellVspImage"])
+	template_vars["Command"] = `[ "/vsp-mrvl" ]`
 	return plugin.NewGrpcPlugin(dpuMode, client, plugin.WithVspImage(template_vars))
 }
 

--- a/internal/platform/marvell-dpu.go
+++ b/internal/platform/marvell-dpu.go
@@ -52,8 +52,8 @@ func (pi *MarvellDetector) IsDpuPlatform() (bool, error) {
 }
 
 func (pi *MarvellDetector) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client) *plugin.GrpcPlugin {
-	MarvellVspImage := vspImages["MarvellVspImage"]
-	return plugin.NewGrpcPlugin(dpuMode, client, plugin.WithVspImage(MarvellVspImage))
+	template_vars := plugin.CreateVspImageVars(vspImages["MarvellVspImage"])
+	return plugin.NewGrpcPlugin(dpuMode, client, plugin.WithVspImage(template_vars))
 }
 
 // GetVendorName returns the name of the vendor

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -132,24 +132,35 @@ func (pi *PlatformInfo) listDpuDevices() ([]ghw.PCIDevice, []VendorDetector, err
 	return dpuDevices, activeDetectors, nil
 }
 
+func (pi *PlatformInfo) detectDpuSystem(required bool) (VendorDetector, error) {
+	dpuDevices, detectors, err := pi.listDpuDevices()
+	if err != nil {
+		return nil, errors.Errorf("Failed to get VspPlugin from platform: %v", err)
+	}
+	if len(dpuDevices) != 1 {
+		if len(dpuDevices) != 0 {
+			return nil, fmt.Errorf("%v DPU devices detected. Currently only supporting exactly 1 DPU per node", len(dpuDevices))
+		}
+		if required {
+			return nil, fmt.Errorf("Failed to detect any DPU devices")
+		}
+		return nil, nil
+	}
+	return detectors[0], nil
+}
+
 func (pi *PlatformInfo) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client) (*plugin.GrpcPlugin, error) {
 	var detector VendorDetector
+	var err error
+
 	if dpuMode {
 		// TODO: We need to also detect the platform in dpuMode
 		detector = NewIntelDetector()
 	} else {
-		dpuDevices, detectors, err := pi.listDpuDevices()
-		if err != nil {
-			return nil, errors.Errorf("Failed to get VspPlugin from platform: %v", err)
-		}
-		if len(dpuDevices) == 0 {
-			return nil, fmt.Errorf("Failed to detect any DPU devices")
-		}
-		if len(dpuDevices) != 1 {
-			return nil, fmt.Errorf("%v DPU devices detected. Currently only supporting exactly 1 DPU per node", len(dpuDevices))
-		}
-
-		detector = detectors[0]
+		detector, err = pi.detectDpuSystem(true)
+	}
+	if err != nil {
+		return nil, err
 	}
 	return detector.VspPlugin(dpuMode, vspImages, client), nil
 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -97,16 +97,8 @@ func (pi *PlatformInfo) GetPcieDevFilter() (string, string, string, error) {
 }
 
 func (pi *PlatformInfo) IsDpu() (bool, error) {
-	for _, detector := range pi.Detectors {
-		isDpu, err := detector.IsDpuPlatform()
-		if err != nil {
-			return false, err
-		}
-		if isDpu {
-			return true, nil
-		}
-	}
-	return false, nil
+	detector, err := pi.detectDpuPlatform(false)
+	return detector != nil, err
 }
 
 func (pi *PlatformInfo) detectDpuPlatform(required bool) (VendorDetector, error) {

--- a/pkgs/render/render.go
+++ b/pkgs/render/render.go
@@ -5,11 +5,11 @@ import (
 	"context"
 	"embed"
 	"fmt"
-	"html/template"
 	"io"
 	"path/filepath"
 	"sort"
 	"strings"
+	"text/template"
 
 	"github.com/go-logr/logr"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/apply"


### PR DESCRIPTION
With #128 merged, there is now a way for starting the VSP plugin from the operator.

However, there are various missing pieces.

Fix some of the issues, in particular to fix starting the Marvell VSP in the DPU.


CC: @bbhamidipati , @alkamah-marvell , @hasan-alkama (FYI)