### PR TITLE
[th/disable-tft-tests] Makefile: disable "deploy_tft_tests" step from "e2e-test" for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ ipu_deploy:
 	bash $(DEPLOY_TFT_SCRIPT)
 
 .PHONY: e2e_test
-e2e-test: ipu_host ipu_deploy deploy_tft_tests
+e2e-test: ipu_host ipu_deploy
 	@echo "E2E Test Completed"
 
 .PHONY: all


### PR DESCRIPTION
It is currently not working yet. Disable it for now, otherwise the "e2e-test" target will fail.

Note that currently there is a bug in "deploy_tft_tests" target, so currently it is also not called. So this change has little effect. However, it will have effect, when that bug is fixed (and the target starts to fail for real).