### PR TITLE
Fix vsp deploy

### DIFF
--- a/internal/daemon/dpudaemon.go
+++ b/internal/daemon/dpudaemon.go
@@ -125,6 +125,7 @@ func (d *DpuDaemon) Listen() (net.Listener, error) {
 	addr, port, err := d.vsp.Start()
 	if err != nil {
 		d.log.Error(err, "Failed to get addr:port from VendorPlugin")
+		return nil, err
 	}
 
 	d.server = grpc.NewServer()

--- a/internal/daemon/hostdaemon.go
+++ b/internal/daemon/hostdaemon.go
@@ -183,6 +183,7 @@ func (d *HostDaemon) Listen() (net.Listener, error) {
 	addr, port, err := d.vsp.Start()
 	if err != nil {
 		d.log.Error(err, "VSP init returned error")
+		return nil, err
 	}
 	d.addr = addr
 	d.port = port

--- a/internal/daemon/plugin/vendorplugin.go
+++ b/internal/daemon/plugin/vendorplugin.go
@@ -21,9 +21,12 @@ import (
 //go:embed bindata/*
 var binData embed.FS
 
+const VspImageIntel string = "IntelVspImage"
+const VspImageMarvell string = "MarvellVspImage"
+
 var VspImages = []string{
-	"IntelVspImage",
-	"MarvellVspImage",
+	VspImageIntel,
+	VspImageMarvell,
 	// TODO: Add future supported vendor plugins here
 }
 

--- a/internal/daemon/plugin/vendorplugin.go
+++ b/internal/daemon/plugin/vendorplugin.go
@@ -106,9 +106,11 @@ func WithVspImage(template_vars map[string]string) func(*GrpcPlugin) {
 		vspImage := template_vars["VendorSpecificPluginImage"]
 		d.vspImage = vspImage
 		d.log.Info("VSP Image", "vspImage", d.vspImage)
-		err := render.ApplyAllFromBinData(d.log, "vsp-ds", template_vars, binData, d.k8sClient, nil, nil)
-		if err != nil {
-			d.log.Error(err, "Failed to start vendor plugin container", "vspImage", d.vspImage)
+		if vspImage != "" {
+			err := render.ApplyAllFromBinData(d.log, "vsp-ds", template_vars, binData, d.k8sClient, nil, nil)
+			if err != nil {
+				d.log.Error(err, "Failed to start vendor plugin container", "vspImage", d.vspImage)
+			}
 		}
 	}
 }

--- a/internal/platform/ipu.go
+++ b/internal/platform/ipu.go
@@ -58,7 +58,7 @@ func (pi *IntelDetector) IsDpuPlatform() (bool, error) {
 }
 
 func (pi *IntelDetector) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client) *plugin.GrpcPlugin {
-	template_vars := plugin.CreateVspImageVars(vspImages["IntelVspImage"])
+	template_vars := plugin.CreateVspImageVars(vspImages[plugin.VspImageIntel])
 	template_vars["Command"] = `[ "/usr/bin/ipuplugin" ]`
 	template_vars["Args"] = `[ "-v=debug" ]`
 	return plugin.NewGrpcPlugin(dpuMode, client, plugin.WithVspImage(template_vars))

--- a/internal/platform/marvell-dpu.go
+++ b/internal/platform/marvell-dpu.go
@@ -52,7 +52,7 @@ func (pi *MarvellDetector) IsDpuPlatform() (bool, error) {
 }
 
 func (pi *MarvellDetector) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client) *plugin.GrpcPlugin {
-	template_vars := plugin.CreateVspImageVars(vspImages["MarvellVspImage"])
+	template_vars := plugin.CreateVspImageVars(vspImages[plugin.VspImageMarvell])
 	template_vars["Command"] = `[ "/vsp-mrvl" ]`
 	return plugin.NewGrpcPlugin(dpuMode, client, plugin.WithVspImage(template_vars))
 }


### PR DESCRIPTION
    daemon: Crash if vsp init fails
    
    In the case that the vsp is not able to be started, the daemon should
    crash and retry.
    
    Currently there is a race condition when deploying the vsp from the
    operator where the vsp may fail to come up by the time "start" is
    called. This patch should address this race by retrying the daemon pod
    deployment.
    
    It makes sense to crash anyways, since the daemon on its own is useless
    without a running vsp, and we want to be able to easily see that an
    error has occured (i.e. daemon ends up in crashLoopBackoff if the vsp is
    never deployed).
    
    GrpcPlugin: Don't deploy vsp if image is not set
    
    Make sure we don't deploy vsp in the case WithVspImage is called with an
    empty vsp string.
    
    plugin: Use string constants for VSP image names