### PR TITLE
Cleanup

### DIFF
--- a/hack/deploy_traffic_flow_tests.sh
+++ b/hack/deploy_traffic_flow_tests.sh
@@ -5,6 +5,13 @@ export KUBECONFIG=/root/kubeconfig.ocpcluster
 nodes=$(oc get nodes)
 export worker=$(echo "$nodes" | grep -oP '^worker-[^\s]*')
 
+
+# wa for https://issues.redhat.com/browse/IIC-364
+make undeploy
+make local-deploy
+oc create -f examples/host.yaml
+sleep 15 # Give times for Intel VSP to configure ip on <ipu-netdev>d3
+
 export KUBECONFIG=/root/kubeconfig.microshift
 nodes=$(oc get nodes)
 export acc=$(echo "$nodes" | grep -oP '^\d{3}-acc')

--- a/internal/platform/ipu.go
+++ b/internal/platform/ipu.go
@@ -58,10 +58,11 @@ func (pi *IntelDetector) IsDpuPlatform() (bool, error) {
 }
 
 func (pi *IntelDetector) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client) *plugin.GrpcPlugin {
-	template_vars := plugin.CreateVspImageVars(vspImages[plugin.VspImageIntel])
-	template_vars["Command"] = `[ "/usr/bin/ipuplugin" ]`
-	template_vars["Args"] = `[ "-v=debug" ]`
-	return plugin.NewGrpcPlugin(dpuMode, client, plugin.WithVspImage(template_vars))
+	template_vars := plugin.NewVspTemplateVars()
+	template_vars.VendorSpecificPluginImage = vspImages[plugin.VspImageIntel]
+	template_vars.Command = `[ "/usr/bin/ipuplugin" ]`
+	template_vars.Args = `[ "-v=debug" ]`
+	return plugin.NewGrpcPlugin(dpuMode, client, plugin.WithVsp(template_vars))
 }
 
 func (d *IntelDetector) GetVendorName() string {

--- a/internal/platform/marvell-dpu.go
+++ b/internal/platform/marvell-dpu.go
@@ -52,9 +52,10 @@ func (pi *MarvellDetector) IsDpuPlatform() (bool, error) {
 }
 
 func (pi *MarvellDetector) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client) *plugin.GrpcPlugin {
-	template_vars := plugin.CreateVspImageVars(vspImages[plugin.VspImageMarvell])
-	template_vars["Command"] = `[ "/vsp-mrvl" ]`
-	return plugin.NewGrpcPlugin(dpuMode, client, plugin.WithVspImage(template_vars))
+	template_vars := plugin.NewVspTemplateVars()
+	template_vars.VendorSpecificPluginImage = vspImages[plugin.VspImageMarvell]
+	template_vars.Command = `[ "/vsp-mrvl" ]`
+	return plugin.NewGrpcPlugin(dpuMode, client, plugin.WithVsp(template_vars))
 }
 
 // GetVendorName returns the name of the vendor


### PR DESCRIPTION
    plugin: Clean up vsp deployment code
    
    We should not deploy the vsp as a side effect of withVspImage. Rather we
    should explicitly call a function to handle deploy the Vsp.

    hack: add wa for IIC-364
    
    After IPU host reboot, the vsp init call fails to set an ip to
    communicate with the ACC. Restart the vsp/daemon to ensure this
    connection is up and ready to recieve cni requests.