### PR TITLE
cluster_configs: change IPU subnet

### DIFF
--- a/cluster_configs/config-dpu.yaml
+++ b/cluster_configs/config-dpu.yaml
@@ -12,7 +12,7 @@ clusters:
       bmc: "{{IMC_hostname(0)}}"
       bmc_user: "root"
       bmc_password: "redhat"
-      ip: "192.168.3.16"
+      ip: "172.16.3.16"
       mac: "{{IPU_mac_address(0)}}"
     postconfig:
     - name: "rh_subscription"


### PR DESCRIPTION
With MeV 1.8 the host physical netdev (i.e. ens2f0) now gets a lease from the dhcpd server it is connected to.

This can cause issues with assisted installer, since CDA uses the subnet 192.168.122.1/16 by default. We should use a subnet that will not
    overlap with the default CDA subnet