### PR TITLE
E2e cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,16 +82,16 @@ DEPLOY_TFT_SCRIPT = hack/deploy_traffic_flow_tests.sh
 .PHONY: default
 default: build
 
-.PHONY: prepare
-prepare:
+.PHONY: prepare-e2e-test
+prepare-e2e-test:
 	bash $(PREPARE_SCRIPT)
 
 .PHONY: ipu_host
-ipu_host:
+ipu_host: prepare-e2e-test
 	bash $(IPU_HOST_SCRIPT)
 
 .PHONY: ipu_deploy
-ipu_deploy:
+ipu_deploy: prepare-e2e-test
 	bash $(IPU_DEPLOY_SCRIPT)
 
 .PHONY: deploy_tft_tests

--- a/hack/deploy_traffic_flow_tests.sh
+++ b/hack/deploy_traffic_flow_tests.sh
@@ -1,5 +1,7 @@
+#!/usr/bin/env bash
+
 cd ocp-traffic-flow-tests
-source ocp-venv/bin/activate
+source /tmp/tft-venv/bin/activate
 
 export KUBECONFIG=/root/kubeconfig.ocpcluster
 nodes=$(oc get nodes)

--- a/hack/ipu_deploy.sh
+++ b/hack/ipu_deploy.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/bin/bin/env bash
+
 cd cluster-deployment-automation
-python3.11 -m venv /tmp/ocp-venv
-source /tmp/ocp-venv/bin/activate
+python3.11 -m venv /tmp/cda-venv
+source /tmp/cda-venv/bin/activate
 
 python3.11 cda.py --secret /root/pull_secret.json ../cluster_configs/config-dpu.yaml deploy
 

--- a/hack/ipu_host_deploy.sh
+++ b/hack/ipu_host_deploy.sh
@@ -1,6 +1,6 @@
 cd cluster-deployment-automation
-python3.11 -m venv /tmp/ocp-venv
-source /tmp/ocp-venv/bin/activate
+python3.11 -m venv /tmp/cda-venv
+source /tmp/cda-venv/bin/activate
 
 python3.11 cda.py --secret /root/pull_secret.json ../cluster_configs/config-dpu-host.yaml deploy 
 

--- a/hack/prepare.sh
+++ b/hack/prepare.sh
@@ -1,16 +1,20 @@
+#!/usr/bin/env bash
+
 git submodule init
 git submodule update
 
 cd cluster-deployment-automation
-systemctl restart libvirtd
-
-rm -rf /tmp/ocp-venv
-
-python3.11 -m venv /tmp/ocp-venv
-source /tmp/ocp-venv/bin/activate
+rm -rf /tmp/cda-venv
+python3.11 -m venv /tmp/cda-venv
+source /tmp/cda-venv/bin/activate
 sh ./dependencies.sh
+deactivate
+cd -
 
-cd ../ocp-traffic-flow-tests
-python3.11 -m venv /tmp/ocp-venv
-source /tmp/ocp-venv/bin/activate
+cd ocp-traffic-flow-tests
+rm -rf /tmp/tft-venv
+python3.11 -m venv /tmp/tft-venv
+source /tmp/tft-venv/bin/activate
 pip3.11 install -r requirements.txt
+deactivate
+cd -


### PR DESCRIPTION
Since prepare might be ran on a different system to init the module, we don't want to start libvirtd. That logic should be part of cda. In addition, don't mix the venv of the two submodules.