### PR TITLE
Fix failing daemon deployment

### DIFF
--- a/bundle/manifests/dpu-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dpu-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-10-04T14:11:42Z"
+    createdAt: "2024-10-15T19:06:53Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
     features.operators.openshift.io/csi: "false"
@@ -164,7 +164,13 @@ spec:
           resources:
           - servicefunctionchains/finalizers
           verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
           - update
+          - watch
         - apiGroups:
           - config.openshift.io
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -89,7 +89,13 @@ rules:
   resources:
   - servicefunctionchains/finalizers
   verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
   - update
+  - watch
 - apiGroups:
   - config.openshift.io
   resources:

--- a/internal/controller/dpuoperatorconfig_controller.go
+++ b/internal/controller/dpuoperatorconfig_controller.go
@@ -60,6 +60,7 @@ func (r *DpuOperatorConfigReconciler) WithImagePullPolicy(policy string) *DpuOpe
 //+kubebuilder:rbac:groups=config.openshift.io,resources=dpuoperatorconfigs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=config.openshift.io,resources=dpuoperatorconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=dpuoperatorconfigs/finalizers,verbs=update
+//+kubebuilder:rbac:groups=config.openshift.io,resources=servicefunctionchains/finalizers,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=roles,resources=*,verbs=get;list;watch;create;update;patch;delete

--- a/manifests/stable/dpu-operator.clusterserviceversion.yaml
+++ b/manifests/stable/dpu-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-10-04T14:11:42Z"
+    createdAt: "2024-10-15T19:06:53Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
     features.operators.openshift.io/csi: "false"
@@ -164,7 +164,13 @@ spec:
           resources:
           - servicefunctionchains/finalizers
           verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
           - update
+          - watch
         - apiGroups:
           - config.openshift.io
           resources:


### PR DESCRIPTION
When bumping the daemon permissions to reconcile the service function
chain, we did not also bump these permissions on the manager.

As a result the controller has been silently failing to deploy the
daemon