### PR TITLE
Fix race + improve error logging + use less common port 

### DIFF
--- a/internal/daemon/dpudaemon.go
+++ b/internal/daemon/dpudaemon.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
 type DpuDaemon struct {
@@ -250,6 +251,9 @@ func (d *DpuDaemon) setupReconcilers() {
 			},
 			// A timout needs to be specified, or else the mananger will wait indefinitely on stop()
 			GracefulShutdownTimeout: &t,
+			Metrics: server.Options{
+				BindAddress: ":18001",
+			},
 		})
 		if err != nil {
 			d.log.Error(err, "unable to start manager")

--- a/internal/daemon/hostdaemon.go
+++ b/internal/daemon/hostdaemon.go
@@ -275,8 +275,8 @@ func (d *HostDaemon) Stop() {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 		defer cancel()
 		d.cniserver.Shutdown(ctx)
-		d.cniserver = nil
 		d.startedWg.Wait()
+		d.cniserver = nil
 	}
 }
 


### PR DESCRIPTION
- Errors were not handled properly in the dpu device plugin
- When an error occurred, it wasn't clear from the test output where the error came from
- 8080 is used frequently. For that reason, change the metrics server port