### PR TITLE
Proper vsp testing

### DIFF
--- a/hack/cluster-configs/config-dpu-host.yaml
+++ b/hack/cluster-configs/config-dpu-host.yaml
@@ -8,6 +8,7 @@ clusters:
     postconfig:
     - name: "dpu_operator_host"
       dpu_operator_path: "../"
+      ipu_plugin_sha: "7b60c3c0c200f7487f76f80aeb77c41228924d40"
     masters:
     - name: "nicmodecluster-master-1"
       kind: "vm"

--- a/hack/cluster-configs/config-dpu.yaml
+++ b/hack/cluster-configs/config-dpu.yaml
@@ -21,4 +21,5 @@ clusters:
     - name: "microshift"
     - name: "dpu_operator_dpu"
       dpu_operator_path: "../"
+      ipu_plugin_sha: "7b60c3c0c200f7487f76f80aeb77c41228924d40"
       rebuild_dpu_operators_images: false

--- a/hack/deploy_traffic_flow_tests.sh
+++ b/hack/deploy_traffic_flow_tests.sh
@@ -7,15 +7,6 @@ export KUBECONFIG=/root/kubeconfig.ocpcluster
 nodes=$(oc get nodes)
 export worker=$(echo "$nodes" | grep -oP '^worker-[^\s]*')
 
-
-# wa for https://issues.redhat.com/browse/IIC-364
-pushd ../
-make undeploy
-make local-deploy
-oc create -f examples/host.yaml
-sleep 45 # Give times for Intel VSP to configure ip on <ipu-netdev>d3
-popd
-
 export KUBECONFIG=/root/kubeconfig.microshift
 nodes=$(oc get nodes)
 export acc=$(echo "$nodes" | grep -oP '^\d{3}-acc')


### PR DESCRIPTION
hack: Track the latest IPU sha we have validated
    
    We are currently just building from tip of vsp, which can make it hard
    to attribute failures to changes that make occur / determine when fixes
    have properly been applied in the vsp.
    
    Lets start tracking the current sha of the vsp that we are building.
    Future changes to the vsp will need to be "validated" by pushing them
    through the CI before we will encorporate those changes into the stable
    solution.

hack: remove wa for IIC-364
    
    In theory, we have addressed the issue in IIC-364 that caused the
    connection from host to acc to be lost on host reboot.
    
    Lets remove this workaround to validate this change has been applied.
    
    Note: we also will remove the reboots we were issuing in the subsequent
    bump to CDA, which means the issue may still be present but masked.
    
    TODO: Add additional stress-testing to validate reboot behavior on
    vendors platforms

