### PR TITLE
Add Host Network Attachment Definition

### DIFF
--- a/internal/controller/bindata/networkfn-nad-host/00.networkfun-nad.yaml
+++ b/internal/controller/bindata/networkfn-nad-host/00.networkfun-nad.yaml
@@ -1,0 +1,17 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sriov-net1
+  namespace: default
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: {{.ResourceName}}
+spec:
+  config: '{
+    "type": "dpu-cni",
+    "cniVersion": "0.4.0",
+    "name": "dpu-cni",
+    "ipam": {
+      "type": "host-local",
+      "subnet": "10.56.217.0/24"
+    }
+    }'

--- a/internal/controller/dpuoperatorconfig_controller.go
+++ b/internal/controller/dpuoperatorconfig_controller.go
@@ -141,7 +141,16 @@ func (r *DpuOperatorConfigReconciler) ensureDpuDeamonSet(ctx context.Context, cf
 func (r *DpuOperatorConfigReconciler) ensureNetworkFunctioNAD(ctx context.Context, cfg *configv1.DpuOperatorConfig) error {
 	logger := log.FromContext(ctx)
 	logger.Info("Create the Network Function NAD")
-	return r.createAndApplyAllFromBinData(logger, "networkfn-nad", cfg)
+	nadFile := ""
+	switch cfg.Spec.Mode {
+	case "dpu":
+		nadFile = "networkfn-nad"
+	case "host":
+		nadFile = "networkfn-nad-host"
+	default:
+		return errors.NewBadRequest("Invalid Mode!")
+	}
+	return r.createAndApplyAllFromBinData(logger, nadFile, cfg)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/dpuoperatorconfig_controller.go
+++ b/internal/controller/dpuoperatorconfig_controller.go
@@ -99,14 +99,13 @@ func (r *DpuOperatorConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	if dpuOperatorConfig.Spec.Mode == "dpu" {
+	if dpuOperatorConfig.Spec.Mode != "auto" {
 		err = r.ensureNetworkFunctioNAD(ctx, dpuOperatorConfig)
 		if err != nil {
 			logger.Error(err, "Failed to create Network Function NAD")
 			return ctrl.Result{}, err
 		}
 	}
-
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
# TL;DR
This PR makes some changes to how we handle Network Attachment Definitions (NAD) in the DPU Operator. The goal is to centralize the NAD setup, and automate the deployment of the NAD for the Host. I'm also hoping to discuss if these changes should be moved to the daemon so we can support auto mode as well.

## What’s Changed
### Host NAD YAML:

Added a manifest for Host NAD to centralize its configuration in the operator itself.
The namespace follows what we use in Cluster Deployment Automation (CDA), so the default resources get nad properly.

### NAD Reconciliation:

Changed the check for NAD to ensure both Host and DPU mode have deployed its NADs while skipping it for Auto mode.

### Auto Mode Handling:

If the configuration is set to auto, the operator will skip NAD deployment since the controller can’t detect the hardware in this mode. This keeps things cleaner and avoids unnecessary errors.

## Why These Changes Matter
By centralizing the Host NAD setup and improving how we handle reconciliation, this makes the operator more reliable and lessens the burden of configuration from the user. I also hope to have a discussion about whether NAD management should be the job of the controller or the daemon, since the latter is the one that can auto detect the hardware.