### PR TITLE
[th/make-generate-tidy] makefile: run `go mod tidy` during `make generate`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,15 @@ prow-ci-manifests-check: manifests
 		exit 1; \
 	fi
 
+.PHONY: vendor
+vendor:
+	for d in . dpu-api api tools ; do \
+		if [ "$$d" = . ] ; then \
+			(cd $$d && go mod vendor) || exit $$? ; \
+		fi ; \
+		(cd $$d && go mod tidy) || exit $$? ; \
+	done
+
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	GOFLAGS='' $(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/Makefile
+++ b/Makefile
@@ -152,24 +152,13 @@ vendor:
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	GOFLAGS='' $(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
-TMP_DIR := $(shell mktemp -d)
 .PHONY: generate-check
 generate-check: controller-gen
-	rm -rf $(TMP_DIR)
-	mkdir -p $(TMP_DIR)
-	cp -r . $(TMP_DIR)
-	cd $(TMP_DIR) && make generate
-	diff -r . $(TMP_DIR) || exit 1
-	rm -rf $(TMP_DIR)
+	./scripts/check-gittree-for-diff.sh make generate
 
 .PHONY: vendor-check
 vendor-check:
-	rm -rf $(TMP_DIR)
-	mkdir -p $(TMP_DIR)
-	cp -r . $(TMP_DIR)
-	cd $(TMP_DIR) && go mod vendor && go mod tidy
-	diff -r . $(TMP_DIR) || exit 1
-	rm -rf $(TMP_DIR)
+	./scripts/check-gittree-for-diff.sh make vendor
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.

--- a/scripts/check-gittree-for-diff.sh
+++ b/scripts/check-gittree-for-diff.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/bash
+
+die() {
+    printf "%s\n" "$*"
+    exit 1
+}
+
+set -e
+
+test $# -gt 0 || die "Usage: $0 CMD..."
+
+cd "$(dirname "$0")/.."
+
+DIR="$(mktemp -t -d dpu-operator-check-gittree-for-diff.XXXX)"
+
+cp -ar ./ "$DIR/"
+
+echo "Checking \`$@\` in \"$DIR\""
+
+pushd "$DIR/" 1>/dev/null
+"$@"
+popd 1>/dev/null
+
+diff -r . "$DIR/" || die "There is a difference between \"$PWD\" and \"$DIR\" after calling \`$@\`"
+
+rm -rf "$DIR/"


### PR DESCRIPTION
We have multiple go.mod files, this does not seem to agree with operator-sdk. operator-sdk will generate files and call `make generate`. However, that will then fail because we didn't call `go mod tidy` for api/ directory.

Note that compared to sriov-network-operator, in dpu-operator we have several go.mod files. That does not seem to agree with operator-sdk, or at least, something is not hooked up right.

Hack `make generate` to call `go mod tidy` first.

Otherwise:
```
  $ git checkout -B C origin/main && \
    git reset --hard HEAD && \
    git clean -fdx && \
    make operator-sdk && \
    ./bin/operator-sdk create webhook --group config --version v1 --kind DpuOperatorConfig --defaulting --programmatic-validation
  branch 'C' set up to track 'origin/main'.
  Reset branch 'C'
  Your branch is up to date with 'origin/main'.
  HEAD is now at e58a9c9c830a Merge pull request #194 from thom311/th/hack-scripts-cleanup
  INFO[0000] Writing kustomize manifests for you to edit...
  ERRO[0000] Unable to find the target #- path: manager_webhook_patch.yaml to uncomment in the file config/default/kustomization.yaml.
  INFO[0000] Writing scaffold for you to edit...
  INFO[0000] api/v1/dpuoperatorconfig_webhook.go
  INFO[0000] api/v1/dpuoperatorconfig_webhook_test.go
  INFO[0000] api/v1/webhook_suite_test.go
  INFO[0000] Update dependencies:
  $ go mod tidy
  INFO[0000] Running make:
  $ make generate
  test -s /data/src/dpu-operator/bin/controller-gen && /data/src/dpu-operator/bin/controller-gen --version | grep -q v0.15.0 || \
  GOBIN=/data/src/dpu-operator/bin GOFLAGS='' go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0
  GOFLAGS='' /data/src/dpu-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
  Error: load packages in root "/data/src/dpu-operator/api": err: exit status 1: stderr: go: updates to go.mod needed; to update it:
          go mod tidy
```