### PR TITLE
[th/revert-device-ids] Revert "deviceHandler: Handle both net dev and pci IDs"

### DIFF
--- a/dpu-cni/pkgs/sriovutils/sriovutils.go
+++ b/dpu-cni/pkgs/sriovutils/sriovutils.go
@@ -49,17 +49,6 @@ func EnableArpAndNdiscNotify(ifName string) error {
 	return nil
 }
 
-// GetPciFromNetDev takes in a network device name and returns its PCI address
-func GetPciFromNetDev(ifName string) (string, error) {
-	netDevPath := filepath.Join(NetDirectory, ifName, "device")
-	pciAddr, err := filepath.EvalSymlinks(netDevPath)
-	if err != nil {
-		return "", fmt.Errorf("failed to find PCI address for net device %s: %v", ifName, err)
-	}
-
-	return filepath.Base(pciAddr), nil
-}
-
 // GetSriovNumVfs takes in a PF name(ifName) as string and returns number of VF configured as int
 func GetSriovNumVfs(ifName string) (int, error) {
 	var vfTotal int
@@ -370,11 +359,6 @@ func SetVFHardwareMAC(netLinkManager NetlinkManager, pfDevice string, vfID int, 
 
 		return nil
 	})
-}
-
-// isValidPCIAddress checks if a provide string is a valid PCI address
-func IsValidPCIAddress(id string) bool {
-	return strings.Count(id, ":") == 2 && strings.Count(id, ".") == 1
 }
 
 // IsValidMACAddress checks if net.HardwareAddr is a valid MAC address.

--- a/internal/daemon/device-handler/dpu-device-handler/dpudevicehandler.go
+++ b/internal/daemon/device-handler/dpu-device-handler/dpudevicehandler.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-logr/logr"
 	pb "github.com/openshift/dpu-operator/dpu-api/gen"
-	"github.com/openshift/dpu-operator/dpu-cni/pkgs/sriovutils"
 	dp "github.com/openshift/dpu-operator/internal/daemon/device-plugin"
 	"github.com/openshift/dpu-operator/internal/utils"
 	"google.golang.org/grpc"
@@ -27,20 +26,6 @@ type dpuDeviceHandler struct {
 	dpuMode          bool
 }
 
-func normalizeDeviceToPci(device string) (string, error) {
-
-	if sriovutils.IsValidPCIAddress(device) {
-		return device, nil
-	}
-
-	pciAddr, err := sriovutils.GetPciFromNetDev(device)
-	if err != nil {
-		return device, fmt.Errorf("failed to get PCI address for netdev %s: %v", device, err)
-	}
-
-	return pciAddr, nil
-}
-
 func (d *dpuDeviceHandler) GetDevices() (*dp.DeviceList, error) {
 	// Wait for devices to be done initializing
 	<-d.setupDevicesDone
@@ -58,11 +43,7 @@ func (d *dpuDeviceHandler) GetDevices() (*dp.DeviceList, error) {
 	devices := make(dp.DeviceList)
 
 	for _, device := range Devices.Devices {
-		devPciId, err := normalizeDeviceToPci(device.ID)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to normalize device %s from GetDevice request: %v", device.ID, err)
-		}
-		devices[devPciId] = pluginapi.Device{ID: devPciId, Health: pluginapi.Healthy}
+		devices[device.ID] = pluginapi.Device{ID: device.ID, Health: pluginapi.Healthy}
 	}
 
 	return &devices, nil


### PR DESCRIPTION
This breaks the unit test

    [FAIL] DPU side maanger Device Plugin [It] Should allocate devices
    /tmp/do/internal/daemon/dpusidemanager_test.go:44

with

    ERROR   DevicePlugin    Failed to get Devices   {"error": "Failed to normalize device ens5f3 from GetDevice request: failed to get PCI address for netdev ens5f3: failed to find PCI address for net device ens5f3: lstat /sys/class/net/ens5f3: no such file or directory"}

The Mock plugin just returns some interface names that don't actually exist and don't have a PCI address. Trying to resolve them as a PCI address does not work. Especially it does not work if that is done by dpuDeviceHandler.GetDevices() as this method is not mocked. To make unit tests work in that case, we would have to mock
dpuDeviceHandler.GetDevices(). But that seems wrong. Instead, this function should not require mocking and just treat the device ID as an opaque identifier.

 > As a result we need to handle the case netdevs are provided. Internally
 > the device plugin expects all devies in PCI address format

Then the device plugin needs to handle that. The places that need to know something about the device (like the PCI address) need to resolve the opaque ID to whatever they need. Possibly by asking the VSP to resolve the ID. That part maybe also needs to be mocked for unit tests.

Also, the patch gives meaning to "pluginapi.Device{ID: devPciId}" without renaming the attribute "ID". That is confusing.

Most importantly. Whatever the solution, revert for now, because this breaks unit tests.

This reverts commit f85129fdac1d18c4d89cccf443e4104b31e1fdea.