### PR TITLE
Enhance Cluster Environment Detection for OSTree-Based and Classic RHEL Systems

### DIFF
--- a/internal/controller/bindata/daemon/99.daemonset.yaml
+++ b/internal/controller/bindata/daemon/99.daemonset.yaml
@@ -49,11 +49,14 @@ spec:
           mountPath: /var/lib/cni
         - name: opt-cni-dir
           mountPath: /opt/cni
-        - name: host-run
+        - name: host-run-netns
           mountPath: /var/run/netns
           mountPropagation: Bidirectional
         - name: proc
           mountPath: /proc
+        - name: host-run
+          mountPath: /var/run
+          readOnly: true
         args:
         - --mode
         - {{.Mode}}
@@ -70,9 +73,12 @@ spec:
         - name: opt-cni-dir
           hostPath:
             path: /opt/cni
-        - name: host-run
+        - name: host-run-netns
           hostPath:
             path: /var/run/netns
         - name: proc
           hostPath:
             path: /proc/
+        - name: host-run
+          hostPath:
+            path: /var/run

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -67,12 +67,12 @@ func NewDaemon(mode string, client client.Client, scheme *runtime.Scheme, vspIma
 
 func (d *Daemon) Run() error {
 	ce := utils.NewClusterEnvironment(d.client)
-	flavour, err := ce.Flavour(context.TODO())
+	flavours, err := ce.Flavours(context.TODO())
 	if err != nil {
 		return err
 	}
-	d.log.Info("Detected OpenShift", "flavour", flavour)
-	err = d.prepareCni(flavour)
+	d.log.Info("Detected Flavours", "flavours", flavours)
+	err = d.prepareCni(flavours)
 	if err != nil {
 		return err
 	}
@@ -88,8 +88,8 @@ func (d *Daemon) Run() error {
 	return daemon.ListenAndServe()
 }
 
-func (d *Daemon) prepareCni(flavour utils.Flavour) error {
-	cniPath, err := d.pm.CniPath(flavour)
+func (d *Daemon) prepareCni(flavours utils.FlavourSet) error {
+	cniPath, err := d.pm.CniPath(flavours)
 	if err != nil {
 		d.log.Error(err, "Failed to get cni path")
 		return err

--- a/internal/utils/cluster_environment.go
+++ b/internal/utils/cluster_environment.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -22,32 +24,82 @@ func NewClusterEnvironment(client client.Client) *ClusterEnvironment {
 }
 
 type Flavour string
+type FlavourSet map[Flavour]struct{}
+
+// Add a flavour to the set
+func (f FlavourSet) Add(flavour Flavour) {
+	f[flavour] = struct{}{}
+}
+
+// Remove a flavour from the set
+func (f FlavourSet) Remove(flavour Flavour) {
+	delete(f, flavour)
+}
+
+// Check if a flavour exists in the set
+func (f FlavourSet) Contains(flavour Flavour) bool {
+	_, exists := f[flavour]
+	return exists
+}
+
+// Convert the set to a slice
+func (f FlavourSet) ToSlice() []Flavour {
+	keys := make([]Flavour, 0, len(f))
+	for key := range f {
+		keys = append(keys, key)
+	}
+	return keys
+}
 
 const (
-	OpenShiftFlavour  Flavour = "OpenShift"
-	MicroShiftFlavour Flavour = "MicroShift"
-	UnknownFlavour    Flavour = "Unknown"
+	OpenShiftFlavour   Flavour = "OpenShift"
+	MicroShiftFlavour  Flavour = "MicroShift"
+	OstreeFlavour      Flavour = "Ostree"
+	ClassicRhelFlavour Flavour = "ClassicRHEL"
+	UnknownFlavour     Flavour = "Unknown"
 )
 
-func (ce *ClusterEnvironment) Flavour(ctx context.Context) (Flavour, error) {
+func (ce *ClusterEnvironment) Flavours(ctx context.Context) (FlavourSet, error) {
+	detectedFlavours := FlavourSet{}
+
 	microShift, err := ce.isMicroShift(ctx)
 	if err != nil {
-		return UnknownFlavour, err
+		return nil, err
 	}
 	if microShift {
-		return MicroShiftFlavour, nil
+		detectedFlavours.Add(MicroShiftFlavour)
 	}
 
 	openShift, err := ce.isOpenShift(ctx)
 	if err != nil {
-		return UnknownFlavour, err
+		return nil, err
 	}
 	if openShift {
-		return OpenShiftFlavour, nil
+		detectedFlavours.Add(OpenShiftFlavour)
 	}
-	return UnknownFlavour, nil
-}
 
+	ostree, err := ce.isOSTree()
+	if err != nil {
+		return nil, err
+	}
+	if ostree {
+		detectedFlavours.Add(OstreeFlavour)
+	}
+
+	classic, err := ce.isClassicRHEL(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if classic {
+		detectedFlavours.Add(ClassicRhelFlavour)
+	}
+
+	if len(detectedFlavours) == 0 {
+		detectedFlavours.Add(UnknownFlavour)
+	}
+
+	return detectedFlavours, nil
+}
 func (ce *ClusterEnvironment) isMicroShift(ctx context.Context) (bool, error) {
 	cm := v1.ConfigMap{}
 	cm.SetName("microshift-version")
@@ -73,4 +125,45 @@ func (ce *ClusterEnvironment) isOpenShift(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("Failed to check if running on openshift: %v", err)
 	}
 	return true, nil
+}
+
+// isClassicRHEL checks if the OS running on the current node is classic RHEL.
+func (ce *ClusterEnvironment) isClassicRHEL(ctx context.Context) (bool, error) {
+	// Retrieve the node name from the K8S_NODE environment variable
+	nodeName := os.Getenv("K8S_NODE")
+	if nodeName == "" {
+		return false, fmt.Errorf("K8S_NODE environment variable is not set")
+	}
+
+	// Fetch the Node object using the Kubernetes client
+	node := &v1.Node{}
+	if err := ce.client.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
+		return false, fmt.Errorf("failed to retrieve node information: %v", err)
+	}
+
+	// Extract OSImage from the node's status
+	osImage := node.Status.NodeInfo.OSImage
+	fmt.Printf("Node OSImage: %s\n", osImage)
+
+	isOstree, err := ce.isOSTree()
+	if err != nil {
+		return false, err
+	}
+	// Determine if the OS is classic RHEL
+	if strings.Contains(osImage, "Red Hat Enterprise Linux") && !isOstree {
+		return true, nil // Classic RHEL detected
+	}
+
+	return false, nil // Not classic RHEL (could be OSTree-based or something else)
+}
+
+// isOSTree checks for the presence of the /run/ostree-booted file to determine if running on OSTree
+func (ce *ClusterEnvironment) isOSTree() (bool, error) {
+	if _, err := os.Stat("/run/ostree-booted"); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil // Not an OSTree-based OS
+		}
+		return false, fmt.Errorf("Failed to check OSTree status: %v", err)
+	}
+	return true, nil // OSTree-based OS detected
 }

--- a/internal/utils/path_manager.go
+++ b/internal/utils/path_manager.go
@@ -34,13 +34,13 @@ func (p *PathManager) PluginEndpointFilename() string {
 	return filepath.Base(p.PluginEndpoint())
 }
 
-func (p *PathManager) CniPath(flavour Flavour) (string, error) {
+func (p *PathManager) CniPath(flavours FlavourSet) (string, error) {
 	// Some k8s cluster flavours use /var/lib (in the case of RHCOS based)
 	// and some use /opt (in the case of RHEL based)
-	switch flavour {
-	case MicroShiftFlavour:
+	switch {
+	case flavours.Contains(ClassicRhelFlavour):
 		return p.wrap("/opt/cni/bin/dpu-cni"), nil
-	case OpenShiftFlavour:
+	case flavours.Contains(OstreeFlavour):
 		return p.wrap("/var/lib/cni/bin/dpu-cni"), nil
 	default:
 		return "", fmt.Errorf("unknown flavour")


### PR DESCRIPTION
This PR shifts the DPU Operator's focus from distinguishing between OpenShift and MicroShift flavors to a more robust approach of identifying the system type (Classic RHEL vs. OSTree-based RHEL). It improves the operator's ability to interact with immutable file systems, ensuring compatibility with modern RHEL variations, including RHEL Image Mode and RHEL CoreOS on DPUs.

**cluster_environment.go**:

Transitioned flavor logic from "OpenShift vs. MicroShift" to identifying "Classic RHEL vs. OSTree-based RHEL."
This change enables the operator to dynamically assess whether the filesystem is immutable and adjust its operations accordingly.
Added support for deployments on RHEL Image Mode and other OSTree-based setups running on the DPU.

**path_manager.go**:

Updated `internal/utils/path_manager.go` to align paths with their respective system flavors.
Adjusted the Classic RHEL flavor to use paths previously associated with the MicroShift flavor.
Allowed OSTree-based systems to leverage the /opt path restrictions and default to OpenShift-like paths.

**99.daemonset.yaml**:

Modified 99.daemonset.yaml to introduce a new host-run mount path for /var/run, by also renaming the mount path `/var/run/netns` to host-run-netns
Added run/ostree-booted to confirm the presence of OSTree environments without creating unnecessary files that might result in false positives.

This PR has been tested on an Intel IPU with 1.8.0 MeV running RHEL Image Mode, where it successfully detects the Ostree flavor and retrieves the correct CNI path.