### PR TITLE
Fix ci v2

### DIFF
--- a/cmd/daemon/daemon.go
+++ b/cmd/daemon/daemon.go
@@ -41,5 +41,8 @@ func main() {
 	vspImages := plugin.CreateVspImagesMap(true, log)
 
 	d := daemon.NewDaemon(mode, client, scheme.Scheme, vspImages, config)
-	d.Run()
+	if err := d.Run(); err != nil {
+		log.Error(err, "Failed to run daemon")
+		panic(err)
+	}
 }

--- a/examples/my-pod.yaml
+++ b/examples/my-pod.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+  namespace: default
+  annotations:
+    k8s.v1.cni.cncf.io/networks: sriov-net1
+spec:
+  nodeSelector:
+    kubernetes.io/hostname: worker-237
+  containers:
+  - name: appcntr1
+    image: registry.access.redhat.com/ubi9/ubi:latest
+    command: ['/bin/sh', '-c', 'sleep infinity']
+    imagePullPolicy: Always
+    securityContext:
+      priviledged: true
+      runAsNonRoot: false
+      runAsUser: 0
+      seccompProfile:
+        type: RuntimeDefault
+    resources:
+      requests:
+        openshift.io/dpu: '1'
+      limits:
+        openshift.io/dpu: '1'

--- a/hack/cluster-configs/config-dpu-host.yaml
+++ b/hack/cluster-configs/config-dpu-host.yaml
@@ -14,14 +14,17 @@ clusters:
       kind: "vm"
       node: "localhost"
       ip: "192.168.122.2"
+      disk_size: 32
     - name: "nicmodecluster-master-2"
       kind: "vm"
       node: "localhost"
       ip: "192.168.122.3"
+      disk_size: 32
     - name: "nicmodecluster-master-3"
       kind: "vm"
       node: "localhost"
       ip: "192.168.122.4"
+      disk_size: 32
     workers:
     - name: "worker-{{worker_number(0)}}"
       kind: "physical"

--- a/hack/cluster-configs/config-dpu-host.yaml
+++ b/hack/cluster-configs/config-dpu-host.yaml
@@ -8,9 +8,10 @@ clusters:
     postconfig:
     - name: "dpu_operator_host"
       dpu_operator_path: "../../"
-      ipu_plugin_sha: "540b6b8cb00fcde8ada0f9ed76dce530744a3cab"
+      ipu_plugin_sha: "0c23d7ef37bf7c5bfdb89958df080644fd5aea3b"
       builder_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/builder:rhel-9-golang-1.22-openshift-4.18"
       base_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/4.18:base-rhel9"
+
     masters:
     - name: "nicmodecluster-master-1"
       kind: "vm"

--- a/hack/cluster-configs/config-dpu-host.yaml
+++ b/hack/cluster-configs/config-dpu-host.yaml
@@ -8,7 +8,7 @@ clusters:
     postconfig:
     - name: "dpu_operator_host"
       dpu_operator_path: "../../"
-      ipu_plugin_sha: "0c23d7ef37bf7c5bfdb89958df080644fd5aea3b"
+      ipu_plugin_sha: "540b6b8cb00fcde8ada0f9ed76dce530744a3cab"
     masters:
     - name: "nicmodecluster-master-1"
       kind: "vm"

--- a/hack/cluster-configs/config-dpu-host.yaml
+++ b/hack/cluster-configs/config-dpu-host.yaml
@@ -9,6 +9,8 @@ clusters:
     - name: "dpu_operator_host"
       dpu_operator_path: "../../"
       ipu_plugin_sha: "540b6b8cb00fcde8ada0f9ed76dce530744a3cab"
+      builder_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/builder:rhel-9-golang-1.22-openshift-4.18"
+      base_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/4.18:base-rhel9"
     masters:
     - name: "nicmodecluster-master-1"
       kind: "vm"

--- a/hack/cluster-configs/config-dpu.yaml
+++ b/hack/cluster-configs/config-dpu.yaml
@@ -12,6 +12,7 @@ clusters:
       bmc: "{{IMC_hostname(0)}}"
       bmc_user: "root"
       bmc_password: "redhat"
+      host_side_bmc: "{{bmc(0)}}"
       ip: "172.16.3.16"
       mac: "{{IPU_mac_address(0)}}"
     postconfig:
@@ -22,4 +23,3 @@ clusters:
     - name: "dpu_operator_dpu"
       dpu_operator_path: "../../"
       ipu_plugin_sha: "0c23d7ef37bf7c5bfdb89958df080644fd5aea3b"
-      host_side_bmc: "{{bmc(0)}}"

--- a/hack/cluster-configs/config-dpu.yaml
+++ b/hack/cluster-configs/config-dpu.yaml
@@ -23,3 +23,5 @@ clusters:
     - name: "dpu_operator_dpu"
       dpu_operator_path: "../../"
       ipu_plugin_sha: "540b6b8cb00fcde8ada0f9ed76dce530744a3cab"
+      builder_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/builder:rhel-9-golang-1.22-openshift-4.18"
+      base_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/4.18:base-rhel9"

--- a/hack/cluster-configs/config-dpu.yaml
+++ b/hack/cluster-configs/config-dpu.yaml
@@ -22,5 +22,4 @@ clusters:
     - name: "dpu_operator_dpu"
       dpu_operator_path: "../../"
       ipu_plugin_sha: "0c23d7ef37bf7c5bfdb89958df080644fd5aea3b"
-      rebuild_dpu_operators_images: false
       host_side_bmc: "{{bmc(0)}}"

--- a/hack/cluster-configs/config-dpu.yaml
+++ b/hack/cluster-configs/config-dpu.yaml
@@ -22,6 +22,6 @@ clusters:
     - name: "microshift"
     - name: "dpu_operator_dpu"
       dpu_operator_path: "../../"
-      ipu_plugin_sha: "540b6b8cb00fcde8ada0f9ed76dce530744a3cab"
+      ipu_plugin_sha: "0c23d7ef37bf7c5bfdb89958df080644fd5aea3b"
       builder_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/builder:rhel-9-golang-1.22-openshift-4.18"
       base_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/4.18:base-rhel9"

--- a/hack/cluster-configs/config-dpu.yaml
+++ b/hack/cluster-configs/config-dpu.yaml
@@ -23,3 +23,4 @@ clusters:
       dpu_operator_path: "../../"
       ipu_plugin_sha: "0c23d7ef37bf7c5bfdb89958df080644fd5aea3b"
       rebuild_dpu_operators_images: false
+      host_side_bmc: "{{bmc(0)}}"

--- a/hack/cluster-configs/config-dpu.yaml
+++ b/hack/cluster-configs/config-dpu.yaml
@@ -22,4 +22,4 @@ clusters:
     - name: "microshift"
     - name: "dpu_operator_dpu"
       dpu_operator_path: "../../"
-      ipu_plugin_sha: "0c23d7ef37bf7c5bfdb89958df080644fd5aea3b"
+      ipu_plugin_sha: "540b6b8cb00fcde8ada0f9ed76dce530744a3cab"

--- a/internal/controller/bindata/daemon/04.daemon_cluster_role.yaml
+++ b/internal/controller/bindata/daemon/04.daemon_cluster_role.yaml
@@ -9,3 +9,9 @@ rules:
   - customresourcedefinitions
   verbs:
   - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -65,29 +65,27 @@ func NewDaemon(mode string, client client.Client, scheme *runtime.Scheme, vspIma
 	}
 }
 
-func (d *Daemon) Run() {
+func (d *Daemon) Run() error {
 	ce := utils.NewClusterEnvironment(d.client)
 	flavour, err := ce.Flavour(context.TODO())
 	if err != nil {
-		d.log.Error(err, "Failed to get cluster flavour")
-		return
+		return err
 	}
 	d.log.Info("Detected OpenShift", "flavour", flavour)
 	err = d.prepareCni(flavour)
 	if err != nil {
-		return
+		return err
 	}
 	dpuMode, err := d.isDpuMode()
 	if err != nil {
-		d.log.Error(err, "Failed to parse mode")
-		return
+		return err
 	}
 	daemon, err := createDaemon(dpuMode, d.config, d.vspImages, d.client)
 	if err != nil {
 		d.log.Error(err, "Failed to start daemon")
-		return
+		return err
 	}
-	daemon.ListenAndServe()
+	return daemon.ListenAndServe()
 }
 
 func (d *Daemon) prepareCni(flavour utils.Flavour) error {

--- a/internal/daemon/dpusidemanager.go
+++ b/internal/daemon/dpusidemanager.go
@@ -125,8 +125,7 @@ func (d *DpuSideManager) Listen() (net.Listener, error) {
 
 	addr, port, err := d.vsp.Start()
 	if err != nil {
-		d.log.Error(err, "Failed to get addr:port from VendorPlugin")
-		return nil, err
+		return nil, fmt.Errorf("Failed to get addr:port from VendorPlugin: %v", err)
 	}
 
 	d.server = grpc.NewServer()
@@ -134,8 +133,7 @@ func (d *DpuSideManager) Listen() (net.Listener, error) {
 
 	lis, err := net.Listen("tcp", fmt.Sprintf("%s:%d", addr, port))
 	if err != nil {
-		d.log.Error(err, "Failed to start listening on", "addr", addr, "port", port)
-		return lis, err
+		return lis, fmt.Errorf("Failed to start listening on %v:%v: %v", addr, port, err)
 	}
 	d.log.Info("server listening", "address", lis.Addr())
 
@@ -155,8 +153,7 @@ func (d *DpuSideManager) ListenAndServe() error {
 	listener, err := d.Listen()
 
 	if err != nil {
-		d.log.Error(err, "Failed to listen")
-		return err
+		return fmt.Errorf("ListenAndServe failed with error: %v", err)
 	}
 
 	return d.Serve(listener)

--- a/internal/daemon/hostsidemanager.go
+++ b/internal/daemon/hostsidemanager.go
@@ -48,12 +48,12 @@ type HostSideManager struct {
 func (d *HostSideManager) CreateBridgePort(pf int, vf int, vlan int, mac string) (*pb.BridgePort, error) {
 	err := d.connectWithRetry()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed to connect with retry: %v", err)
 	}
 
 	m, err := net.ParseMAC(mac)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed to parse Mac: %v", err)
 	}
 
 	createRequest := &pb.CreateBridgePortRequest{
@@ -129,8 +129,7 @@ func (d *HostSideManager) connectWithRetry() error {
 
 	conn, err := grpc.Dial(fmt.Sprintf("%s:%d", d.addr, d.port), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultServiceConfig(retryPolicy))
 	if err != nil {
-		d.log.Error(err, "did not connect")
-		return err
+		return fmt.Errorf("connectWithRetry dial failed: %v", err)
 	}
 	d.log.Info("Dial succeeded", "addr", d.addr, "port", d.port)
 	d.conn = conn


### PR DESCRIPTION
Update CDA in a few notable ways:

- Add a cold boot after IPU installation to ensure idpf state is idempotent between runs
- Deploy P4 container as a daemonset in microshift to ensure it restarts automatically on ACC reboot / is managed by OCP. Enable hugepages manually on the node to allow for deploying
- Add additional checks to detect failures earlier
- Bug fixes