### PR TITLE
[th/buildah-no-authfile] build: don't use `--authfile /root/config.json` for buildah commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,16 +267,16 @@ local-buildx: prepare-multi-arch ## Build all container images necessary to run 
 	mkdir -p $(GO_CONTAINER_CACHE)
 	buildah manifest rm $(DPU_OPERATOR_IMAGE)-manifest || true
 	buildah manifest create $(DPU_OPERATOR_IMAGE)-manifest
-	buildah build --layers --manifest $(DPU_OPERATOR_IMAGE)-manifest --platform linux/amd64,linux/arm64 -v $(GO_CONTAINER_CACHE):/go:z -f Dockerfile.rhel -t $(DPU_OPERATOR_IMAGE)
+	buildah build $(LOCAL_BUILDX_ARGS) --layers --manifest $(DPU_OPERATOR_IMAGE)-manifest --platform linux/amd64,linux/arm64 -v $(GO_CONTAINER_CACHE):/go:z -f Dockerfile.rhel -t $(DPU_OPERATOR_IMAGE)
 	buildah manifest rm $(DPU_DAEMON_IMAGE)-manifest || true
 	buildah manifest create $(DPU_DAEMON_IMAGE)-manifest
-	buildah build --layers --manifest $(DPU_DAEMON_IMAGE)-manifest --platform linux/amd64,linux/arm64 -v $(GO_CONTAINER_CACHE):/go:z -f Dockerfile.daemon.rhel -t $(DPU_DAEMON_IMAGE)
+	buildah build $(LOCAL_BUILDX_ARGS) --layers --manifest $(DPU_DAEMON_IMAGE)-manifest --platform linux/amd64,linux/arm64 -v $(GO_CONTAINER_CACHE):/go:z -f Dockerfile.daemon.rhel -t $(DPU_DAEMON_IMAGE)
 	buildah manifest rm $(MARVELL_VSP_IMAGE)-manifest || true
 	buildah manifest create $(MARVELL_VSP_IMAGE)-manifest
-	buildah build --layers --manifest $(MARVELL_VSP_IMAGE)-manifest --platform linux/amd64,linux/arm64 -v $(GO_CONTAINER_CACHE):/go:z -f Dockerfile.mrvlVSP.rhel -t $(MARVELL_VSP_IMAGE)
+	buildah build $(LOCAL_BUILDX_ARGS) --layers --manifest $(MARVELL_VSP_IMAGE)-manifest --platform linux/amd64,linux/arm64 -v $(GO_CONTAINER_CACHE):/go:z -f Dockerfile.mrvlVSP.rhel -t $(MARVELL_VSP_IMAGE)
 	buildah manifest rm $(INTEL_VSP_IMAGE)-manifest || true
 	buildah manifest create $(INTEL_VSP_IMAGE)-manifest
-	buildah build --layers --manifest $(INTEL_VSP_IMAGE)-manifest --platform linux/amd64,linux/arm64 -v $(GO_CONTAINER_CACHE):/go:z -f Dockerfile.IntelVSP.rhel -t $(INTEL_VSP_IMAGE)
+	buildah build $(LOCAL_BUILDX_ARGS) --layers --manifest $(INTEL_VSP_IMAGE)-manifest --platform linux/amd64,linux/arm64 -v $(GO_CONTAINER_CACHE):/go:z -f Dockerfile.IntelVSP.rhel -t $(INTEL_VSP_IMAGE)
 
 .PHONY: local-pushx
 local-pushx: ## Push all container images necessary to run the whole operator


### PR DESCRIPTION
"/root/config.json" is only accessible to root, which means it makes the build not usable to regular users. That is bad.

Instead, if the build will require a login, then require the caller to first issue a suitable `podman login registry.ci.openshift.org` or configure podman in a similar way, so that a subsequent pull works.  If the user prefers to use files, they still can put the auth file to the well known place, but that place is "/run/user/$UID/containers/auth.json" or "~/.config/containers/auth.json", not "/root/config.json".

That is essentially the same as before: the caller must prepare the system in a way so that pull is gonna work. Except, now they have all the options that podman (e.g. `podman login`) offers, instead of hard coding some file at "/root/config.json".

You can migrate those machines with:

    #BASEDIR=/run/user/0
    BASEDIR=~/.config
    mkdir -p $BASEDIR/containers
    chmod 700 $BASEDIR/containers
    cp /root/config.json $BASEDIR/containers/auth.json
    chmod 600 $BASEDIR/containers/auth.json