### PR TITLE
hack: Be explicit with image rebuild behavior

### DIFF
--- a/hack/cluster-configs/config-dpu-host.yaml
+++ b/hack/cluster-configs/config-dpu-host.yaml
@@ -8,10 +8,10 @@ clusters:
     postconfig:
     - name: "dpu_operator_host"
       dpu_operator_path: "../../"
+      rebuild_dpu_operators_images: "false"
       ipu_plugin_sha: "0c23d7ef37bf7c5bfdb89958df080644fd5aea3b"
       builder_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/builder:rhel-9-golang-1.22-openshift-4.18"
       base_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/4.18:base-rhel9"
-
     masters:
     - name: "nicmodecluster-master-1"
       kind: "vm"

--- a/hack/cluster-configs/config-dpu.yaml
+++ b/hack/cluster-configs/config-dpu.yaml
@@ -22,6 +22,7 @@ clusters:
     - name: "microshift"
     - name: "dpu_operator_dpu"
       dpu_operator_path: "../../"
+      rebuild_dpu_operators_images: "true"
       ipu_plugin_sha: "0c23d7ef37bf7c5bfdb89958df080644fd5aea3b"
       builder_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/builder:rhel-9-golang-1.22-openshift-4.18"
       base_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/4.18:base-rhel9"


### PR DESCRIPTION
Ensure that we only rebuild the images once per CI run. Include a bump to CDA to ensure the correct images are available when testing.