### PR TITLE
[IIC-425] Remove race condition between pod/vsp

### DIFF
--- a/hack/cluster-configs/config-dpu-host.yaml
+++ b/hack/cluster-configs/config-dpu-host.yaml
@@ -9,7 +9,7 @@ clusters:
     - name: "dpu_operator_host"
       dpu_operator_path: "../../"
       rebuild_dpu_operators_images: "false"
-      ipu_plugin_sha: "540b6b8cb00fcde8ada0f9ed76dce530744a3cab"
+      ipu_plugin_sha: "81c6a0e9fe8cefee4cdac88a6a20bbc6b81e0df3"
       builder_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/builder:rhel-9-golang-1.22-openshift-4.18"
       base_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/4.18:base-rhel9"
     masters:

--- a/hack/cluster-configs/config-dpu.yaml
+++ b/hack/cluster-configs/config-dpu.yaml
@@ -23,6 +23,6 @@ clusters:
     - name: "dpu_operator_dpu"
       dpu_operator_path: "../../"
       rebuild_dpu_operators_images: "true"
-      ipu_plugin_sha: "540b6b8cb00fcde8ada0f9ed76dce530744a3cab"
+      ipu_plugin_sha: "81c6a0e9fe8cefee4cdac88a6a20bbc6b81e0df3"
       builder_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/builder:rhel-9-golang-1.22-openshift-4.18"
       base_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/4.18:base-rhel9"


### PR DESCRIPTION
This commit introduces intel/ipu-opi-plugins@81c6a0e to remove the race condition between the vsp and p4 pod initializing.

We also remove the corresponding workaround in the automation script to wait for the p4 to finish initializing before proceeding.