### PR TITLE
[IIC-427] Remove need to run ipu_port1 manually

### DIFF
--- a/hack/cluster-configs/config-dpu-host.yaml
+++ b/hack/cluster-configs/config-dpu-host.yaml
@@ -9,7 +9,7 @@ clusters:
     - name: "dpu_operator_host"
       dpu_operator_path: "../../"
       rebuild_dpu_operators_images: "false"
-      ipu_plugin_sha: "81c6a0e9fe8cefee4cdac88a6a20bbc6b81e0df3"
+      ipu_plugin_sha: "f01e94e22c07a54d3d4f26dca28e89b65cb3678f"
       builder_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/builder:rhel-9-golang-1.22-openshift-4.18"
       base_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/4.18:base-rhel9"
     masters:

--- a/hack/cluster-configs/config-dpu.yaml
+++ b/hack/cluster-configs/config-dpu.yaml
@@ -23,6 +23,6 @@ clusters:
     - name: "dpu_operator_dpu"
       dpu_operator_path: "../../"
       rebuild_dpu_operators_images: "true"
-      ipu_plugin_sha: "81c6a0e9fe8cefee4cdac88a6a20bbc6b81e0df3"
+      ipu_plugin_sha: "f01e94e22c07a54d3d4f26dca28e89b65cb3678f"
       builder_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/builder:rhel-9-golang-1.22-openshift-4.18"
       base_image: "wsfd-advnetlab-amp04.anl.eng.bos2.dc.redhat.com:5000/ocp/4.18:base-rhel9"


### PR DESCRIPTION
We should no longer need to hack a script to ensure primary networking is working at all times. This should be handled by the VSP now.