### PR TITLE
Add CBP(),DBP()  to Marvell VSP

### DIFF
--- a/internal/daemon/vendor-specific-plugins/marvell/00.daemonset.yaml
+++ b/internal/daemon/vendor-specific-plugins/marvell/00.daemonset.yaml
@@ -43,6 +43,10 @@ spec:
               mountPropagation: Bidirectional
             - name: proc
               mountPath: /proc
+            - name: ovs-bin
+              mountPath: /usr/local/bin/
+            - name: ovs-db
+              mountPath: /usr/local/var/run/openvswitch/
       volumes:
         - name: mrvl-vsp-mount
           hostPath:
@@ -53,3 +57,9 @@ spec:
         - name: proc
           hostPath:
             path: /proc/
+        - name: ovs-bin
+          hostPath:
+            path: /usr/local/bin/
+        - name: ovs-db
+          hostPath:
+            path: /usr/local/var/run/openvswitch/

--- a/internal/daemon/vendor-specific-plugins/marvell/debug-dp/debugdp.go
+++ b/internal/daemon/vendor-specific-plugins/marvell/debug-dp/debugdp.go
@@ -1,0 +1,41 @@
+package DebugDP
+
+import (
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type DebugDP struct {
+	log logr.Logger
+}
+
+func NewDebugDP() *DebugDP {
+	return &DebugDP{
+		log: ctrl.Log.WithName("MarvellVSP:DebugDP"),
+	}
+}
+
+func (debugDP *DebugDP) AddPortToDataPlane(bridgeName string, portName string, vfPCIAddres string, isDPDK bool) error {
+	debugDP.log.Info("AddPortToBridge ", "bridgeName", bridgeName, "PortName", portName)
+	return nil
+}
+
+func (debugDP *DebugDP) DeletePortFromDataPlane(bridgeName string, portName string) error {
+	debugDP.log.Info("DeletePortFromBridge ", "bridgeName", bridgeName, "PortName", portName)
+	return nil
+
+}
+
+func (debugDP *DebugDP) InitDataPlane(bridgeName string) error {
+	debugDP.log.Info("Init Data plane", "bridgeName", bridgeName)
+	return nil
+}
+
+func (debugDP *DebugDP) ReadAllPortFromDataPlane(bridgeName string) (string, error) {
+	debugDP.log.Info("ReadAllPortFromBridge ", "bridgeName", bridgeName)
+	return "", nil
+}
+func (debugDP *DebugDP) DeleteDataplane(bridgeName string) error {
+	debugDP.log.Info("DeleteDataplane", "bridgeName", bridgeName)
+	return nil
+}

--- a/internal/daemon/vendor-specific-plugins/marvell/mrvl-utils/mrvlutils.go
+++ b/internal/daemon/vendor-specific-plugins/marvell/mrvl-utils/mrvlutils.go
@@ -1,0 +1,180 @@
+package mrvlutils
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jaypipes/ghw"
+	"github.com/vishvananda/netlink"
+	"k8s.io/klog/v2"
+)
+
+const (
+	VendorID         = "177d" // vendor ID for Marvell OCTEON
+	deviceID         = "a0f7" // device ID for Marvell OCTEON(CN10K) SDP Interface
+	SysBusPci string = "/sys/bus/pci/devices"
+)
+
+// Mapped_VF returns the PCI address of the VF mapped to the given PF
+func Mapped_VF(pf_count int, pfid int, vfid int) (string, error) {
+	pci, err := ghw.PCI()
+	if err != nil {
+		return "", err
+	}
+
+	devices := pci.Devices
+	var list []string
+	for _, device := range devices {
+		if device.Vendor != nil && device.Product != nil {
+			if device.Vendor.ID == VendorID &&
+				device.Product.ID == deviceID {
+				list = append(list, device.Address)
+			}
+		}
+	}
+	dpu_vfid := pf_count*vfid + pfid
+	size := len(list) - 1
+	if dpu_vfid >= size {
+		return "", errors.New("mapped VF out of bounds")
+	}
+
+	vf_pci := strings.Split(list[dpu_vfid], " ")
+	return vf_pci[0], nil
+}
+
+// getInterfaceName function to get the Interface Name of the given Device ID and vendor ID
+// It will return the Interface Name and error
+func GetNameByDeviceID(deviceID string) (string, error) {
+	targetVendorID := VendorID
+	targetDeviceID := deviceID
+	pci, err := ghw.PCI()
+	if err != nil {
+		return "", err
+	}
+	var pciAddress string
+	for _, device := range pci.Devices {
+		if device.Vendor != nil && device.Product != nil {
+			if device.Vendor.ID == targetVendorID && device.Product.ID == targetDeviceID {
+				pciAddress = device.Address
+				break
+			}
+		}
+	}
+	if pciAddress == "" {
+		return "", fmt.Errorf("device not found with Vendor ID: %s and Device ID: %s", targetVendorID, targetDeviceID)
+	}
+	ifname, err := GetNameByPCI(pciAddress)
+	if err != nil {
+		return "", err
+	}
+	return ifname, nil
+}
+
+// GetInterfaceName returns the Name of Interface of  network device forthe given PCI address
+func GetNameByPCI(pciAddress string) (string, error) {
+	pfSymLink := filepath.Join(SysBusPci, pciAddress, "net")
+	_, err := os.Lstat(pfSymLink)
+	if err != nil {
+		return "", err
+	}
+
+	files, err := os.ReadDir(pfSymLink)
+	if err != nil {
+		return "", err
+	}
+
+	if len(files) < 1 {
+		return "", errors.New("PF network device not found")
+	}
+
+	return strings.TrimSpace(files[0].Name()), nil
+}
+
+// GetPCIByDeviceID returns the First Interface's PCI address of the device for the given device ID
+func GetPCIByDeviceID(deviceID string) (string, error) {
+	targetVendorID := VendorID
+	targetDeviceID := deviceID
+	pci, err := ghw.PCI()
+	if err != nil {
+		return "", err
+	}
+	var pciAddress string
+	for _, device := range pci.Devices {
+		if device.Vendor != nil && device.Product != nil {
+			if device.Vendor.ID == targetVendorID && device.Product.ID == targetDeviceID {
+				pciAddress = device.Address
+				break
+			}
+		}
+	}
+	if pciAddress == "" {
+		return "", fmt.Errorf("device not found with Vendor ID: %s and Device ID: %s", targetVendorID, targetDeviceID)
+	}
+	return pciAddress, nil
+}
+
+// Print DPDK port info prints information of dpdk port with given pci address
+func PrintDPDKPortInfo(pciAddress string) error {
+	// pciAddress := "0000:03:00.0"
+	// Get PCI device information
+	pci, err := ghw.PCI()
+	if err != nil {
+		return err
+	}
+	// Find the network interface associated with the PCI address
+	var IfName string
+	for _, device := range pci.Devices {
+		if device.Address == pciAddress {
+			IfName = device.Product.Name
+			break
+		}
+	}
+	if IfName == "" {
+		klog.Errorf("No network interface found for PCI address %s", pciAddress)
+		return errors.New("no network interface found for PCI address")
+	}
+	// Get network interface details
+	IntfDetails, err := net.InterfaceByName(IfName)
+	if err != nil {
+		klog.Errorf("Error fetching interface %s: %v", IfName, err)
+		return err
+	}
+	// Print interface details
+	klog.Infof("Interface Name: %s\n", IntfDetails.Name)
+	klog.Infof("MAC Address: %s\n", IntfDetails.HardwareAddr)
+	klog.Infof("MTU: %d\n", IntfDetails.MTU)
+	return nil
+}
+
+// PrintPortInfo prints the information of Interface with given portName visible to kernel
+func PrintPortInfo(portName string) error {
+	link, err := netlink.LinkByName(portName)
+	if err != nil {
+		klog.Errorf("Error fetching interface %s: %v", portName, err)
+		return err
+	}
+	addrs, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+	if err != nil {
+		klog.Errorf("Error fetching addresses for interface %s: %v", portName, err)
+		return err
+	}
+	klog.Infof("Interface Name: %s", link.Attrs().Name)
+	klog.Infof("Hardware Address (MAC): %s", link.Attrs().HardwareAddr)
+	klog.Infof("MTU: %d", link.Attrs().MTU)
+	for _, addr := range addrs {
+		klog.Infof("Address: %s", addr.IP.String())
+	}
+	return nil
+}
+func GetPCIByName(portName string) (string, error) {
+	link, err := netlink.LinkByName(portName)
+	if err != nil {
+		klog.Errorf("Error fetching interface %s: %v", portName, err)
+		return "", err
+	}
+	return link.Attrs().Name, nil
+}

--- a/internal/daemon/vendor-specific-plugins/marvell/ovs-dp/ovsdp.go
+++ b/internal/daemon/vendor-specific-plugins/marvell/ovs-dp/ovsdp.go
@@ -1,0 +1,107 @@
+package ovsdp
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/go-logr/logr"
+	mrvlutils "github.com/openshift/dpu-operator/internal/daemon/vendor-specific-plugins/marvell/mrvl-utils"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	ovsDbPath  = "/var/run/openvswitch/db.sock"
+	ovsCliPath = "/usr/local/bin/ovs-vsctl"
+	deviceId   = "a063"
+)
+
+type OvsDP struct {
+	bridgeName string
+	ovsDBPath  string
+	ovsCLIPath string
+	log        logr.Logger
+}
+
+func NewOvsDP() *OvsDP {
+	return &OvsDP{
+		log:        ctrl.Log.WithName("MarvellVSP:OvsDP"),
+		bridgeName: "br0",
+		ovsDBPath:  ovsDbPath,
+		ovsCLIPath: ovsCliPath,
+	}
+}
+
+// CreateDBParam creates the db parameter for ovs-vsctl command
+func createDbParam(ovsDbPath string) string {
+	return "--db=unix:" + ovsDbPath
+}
+
+// ovs-vsctl command to add dpdk port to bridge
+func (ovsdp *OvsDP) AddPortToDataPlane(bridgeName string, portName string, vfPCIAddres string, isDPDK bool) error {
+	var cmd *exec.Cmd
+	if isDPDK {
+		ovsdp.log.Info("Adding DPDK Port to Bridge", "PortName", portName, "VFPCIAddress", vfPCIAddres)
+		cmd = exec.Command("ovs-vsctl", "--may-exist", "add-port", bridgeName, portName, "--", "set", "Interface", portName, "type=dpdk", fmt.Sprintf("options:dpdk-devargs=%s", vfPCIAddres))
+
+	} else {
+		ovsdp.log.Info("Adding Port to Bridge", "PortName", portName)
+		cmd = exec.Command("ovs-vsctl", "--may-exist", "add-port", bridgeName, portName)
+
+	}
+	return cmd.Run()
+}
+
+// ovs-vsctl command to delete dpdk-port from bridge
+func (ovsdp *OvsDP) DeletePortFromDataPlane(bridgeName string, portName string) error {
+	ovsdp.log.Info("Deleting Port from Bridge", "PortName", portName)
+	cmd := exec.Command("ovs-vsctl", "del-port", bridgeName, portName)
+	return cmd.Run()
+}
+
+// ovs-vsctl command to delete ovs bridge
+func (ovsdp *OvsDP) DeleteDataplane(bridgeName string) error {
+	cmd := exec.Command("ovs-vsctl", "del-br", bridgeName)
+	return cmd.Run()
+}
+
+// ovs-vsctl command to create bridge
+func createBridge(bridgeName string) error {
+	cmd := exec.Command("ovs-vsctl", "--may-exist", "add-br", bridgeName, "--", "set", "bridge", bridgeName, "datapath_type=netdev")
+	return cmd.Run()
+}
+
+// InitDataPlane initializes the data path in this case it creates an ovs bridge
+func (ovsdp *OvsDP) InitDataPlane(bridgeName string) error {
+	ovsdp.log.Info("Initializing OVS-DPDK Data Plane")
+	ovsdp.bridgeName = bridgeName
+	// "br0" For Testing Purpose
+	if err := createBridge(bridgeName); err != nil {
+		ovsdp.log.Error(err, "Error occurred in creating Bridge")
+		return err
+
+	}
+	ovsdp.log.Info("OVS-DPDK Bridge Created Successfully", "BridgeName", bridgeName)
+	// Get the name of interface from device id with device id as "a063"
+	// a063 is the device id of RPM interface
+	portName, err := mrvlutils.GetNameByDeviceID(deviceId)
+	if err != nil {
+		ovsdp.log.Error(err, "Error occurred in getting RPM Interface")
+	}
+	// Add the port to the bridge
+	if err := ovsdp.AddPortToDataPlane(bridgeName, portName, "", false); err != nil {
+		ovsdp.log.Error(err, "Error occurred in adding RPM interface to Bridge")
+	}
+	ovsdp.log.Info("RPM Interface Added to Bridge Successfully", "PortName", portName)
+	return nil
+}
+
+// ReadPortFromBridge reads all the ports from the bridge
+func (ovsdp *OvsDP) ReadAllPortFromDataPlane(bridgeName string) (string, error) {
+	cmd := exec.Command("ovs-vsctl", "--may-exist", "list-ports", bridgeName)
+	out, err := cmd.Output()
+	if err != nil {
+		ovsdp.log.Error(err, "Error occurred in reading ports from Bridge")
+		return "", err
+	}
+	return string(out), nil
+}


### PR DESCRIPTION
This Commits adds CreateBridgePort() and DeleteBridgePort() API Support
for Marvell VSP Additionally, it integrates the OVS with netdev or DPDK data plane
and  debug data plane functionality for better debugging  within Marvell VSP