### PR TITLE
[th/cluster-config-network-api-port] cluster-configs: set "network_api_port" from ANL lab list

### DIFF
--- a/hack/cluster-configs/config-dpu-host.yaml
+++ b/hack/cluster-configs/config-dpu-host.yaml
@@ -4,7 +4,7 @@ clusters:
     ingress_vip: "192.168.122.101"
     kubeconfig: "/root/kubeconfig.ocpcluster"
     version: "4.19.0-nightly"
-    network_api_port: "eno12399"
+    network_api_port: "{{api_network()}}"
     postconfig:
     - name: "dpu_operator_host"
       dpu_operator_path: "../../"


### PR DESCRIPTION
With this change, the "network_api_port" comes from the google spread sheet. This makes the config also work on the Marvell clusters 15 and 16 which happen to use "eno1" interface (as indicated in the spread sheet).

---

Spin-off from #255 .