### PR TITLE
[th/hack-scripts-cleanup] cleanup hack scripts w.r.t. python and venv

### DIFF
--- a/hack/both.sh
+++ b/hack/both.sh
@@ -3,7 +3,6 @@
 set -e
 
 cd cluster-deployment-automation
-python3.11 -m venv /tmp/cda-venv
 source /tmp/cda-venv/bin/activate
 
 # Tear down any previous cluster fully

--- a/hack/both.sh
+++ b/hack/both.sh
@@ -6,10 +6,10 @@ cd cluster-deployment-automation
 source /tmp/cda-venv/bin/activate
 
 # Tear down any previous cluster fully
-python3.11 cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy -f
+./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy -f
 
 parallel -u --halt 2 ::: \
-  "python3.11 cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu.yaml deploy && echo 'Successfully Deployed ISO Cluster'" \
-  "python3.11 cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy --steps pre,masters && echo 'Successfully Deployed DPU host Cluster'"
+  "./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu.yaml deploy && echo 'Successfully Deployed ISO Cluster'" \
+  "./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy --steps pre,masters && echo 'Successfully Deployed DPU host Cluster'"
 
-python3.11 cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy --steps workers,post && echo "Successfully Deployed DPU host Cluster"
+./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy --steps workers,post && echo "Successfully Deployed DPU host Cluster"

--- a/hack/deploy_traffic_flow_tests.sh
+++ b/hack/deploy_traffic_flow_tests.sh
@@ -28,4 +28,4 @@ envsubst < ../hack/cluster-configs/ocp-tft-config.yaml > tft_config.yaml
 # Give dpu operator pods time to settle to ensure pods will successfully create
 sleep 100
 
-python3.11 main.py tft_config.yaml
+python main.py tft_config.yaml

--- a/hack/ipu_deploy.sh
+++ b/hack/ipu_deploy.sh
@@ -6,9 +6,9 @@ cd cluster-deployment-automation
 source /tmp/cda-venv/bin/activate
 
 # Tear down any previous cluster fully
-python3.11 cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy -f
+./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy -f
 
-python3.11 cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu.yaml deploy
+./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu.yaml deploy
 
 ret=$?
 if [ $ret == 0 ]; then

--- a/hack/ipu_deploy.sh
+++ b/hack/ipu_deploy.sh
@@ -3,7 +3,6 @@
 set -e
 
 cd cluster-deployment-automation
-python3.11 -m venv /tmp/cda-venv
 source /tmp/cda-venv/bin/activate
 
 # Tear down any previous cluster fully

--- a/hack/ipu_deploy_post.sh
+++ b/hack/ipu_deploy_post.sh
@@ -5,7 +5,7 @@ set -e
 cd cluster-deployment-automation
 source /tmp/cda-venv/bin/activate
 
-python3.11 cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu.yaml deploy -s post
+./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu.yaml deploy -s post
 
 ret=$?
 if [ $ret == 0 ]; then

--- a/hack/ipu_deploy_post.sh
+++ b/hack/ipu_deploy_post.sh
@@ -3,7 +3,6 @@
 set -e
 
 cd cluster-deployment-automation
-python3.11 -m venv /tmp/cda-venv
 source /tmp/cda-venv/bin/activate
 
 python3.11 cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu.yaml deploy -s post

--- a/hack/ipu_host_deploy.sh
+++ b/hack/ipu_host_deploy.sh
@@ -5,7 +5,7 @@ set -e
 cd cluster-deployment-automation
 source /tmp/cda-venv/bin/activate
 
-python3.11 cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy
+./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy
 
 ret=$?
 if [ $ret == 0 ]; then

--- a/hack/ipu_host_deploy.sh
+++ b/hack/ipu_host_deploy.sh
@@ -3,7 +3,6 @@
 set -e
 
 cd cluster-deployment-automation
-python3.11 -m venv /tmp/cda-venv
 source /tmp/cda-venv/bin/activate
 
 python3.11 cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy

--- a/hack/ipu_host_deploy_post.sh
+++ b/hack/ipu_host_deploy_post.sh
@@ -3,7 +3,6 @@
 set -e
 
 cd cluster-deployment-automation
-python3.11 -m venv /tmp/cda-venv
 source /tmp/cda-venv/bin/activate
 
 python3.11 cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy -s post

--- a/hack/ipu_host_deploy_post.sh
+++ b/hack/ipu_host_deploy_post.sh
@@ -5,7 +5,7 @@ set -e
 cd cluster-deployment-automation
 source /tmp/cda-venv/bin/activate
 
-python3.11 cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy -s post
+./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy -s post
 
 ret=$?
 if [ $ret == 0 ]; then

--- a/hack/prepare-venv.sh
+++ b/hack/prepare-venv.sh
@@ -14,6 +14,6 @@ cd ocp-traffic-flow-tests
 rm -rf /tmp/tft-venv
 python3.11 -m venv /tmp/tft-venv
 source /tmp/tft-venv/bin/activate
-pip3.11 install -r requirements.txt
+pip install -r requirements.txt
 deactivate
 cd -


### PR DESCRIPTION
Some minor cleanup.

- hack: drop unnecessary "python3.11 -m venv /tmp/cda-venv"
- hack: call ./cda.py directly without explicit python interpreter
- hack: don't call versioned pip/python binaries
