### PR TITLE
[th/mrvl-enable-ipv6-link-local] [V2] rework configuring IPv6 link local addresses for Marvell VSP

### DIFF
--- a/internal/daemon/plugin/bindata/vsp-ds/99.vendor-plugin-daemonset.yaml
+++ b/internal/daemon/plugin/bindata/vsp-ds/99.vendor-plugin-daemonset.yaml
@@ -23,6 +23,7 @@ spec:
         imagePullPolicy: {{.ImagePullPolicy}}
         securityContext:
           privileged: true
+          runAsUser: 0
         command: {{.Command}}
         args: {{.Args}}
         volumeMounts:

--- a/internal/daemon/vendor-specific-plugins/marvell/main.go
+++ b/internal/daemon/vendor-specific-plugins/marvell/main.go
@@ -264,6 +264,8 @@ func (vsp *mrvlVspServer) dpuIpPort() (pb.IpPort, error) {
 		klog.Errorf("Error occurred in getting Interface Name: %v", err)
 		return pb.IpPort{}, err
 	}
+	klog.Infof("Interface Name: %s", IfName)
+
 	err = enableIPV6LinkLocal(IfName)
 	if err != nil {
 		klog.Errorf("Error occurred in enabling IPv6 Link local Address: %v", err)
@@ -309,7 +311,8 @@ func (vsp *mrvlVspServer) hostIpPort() (pb.IpPort, error) {
 		klog.Errorf("Error occurred in getting Interface Name: %v", err)
 		return pb.IpPort{}, err
 	}
-	klog.Infof("Interface Name  InterfaceName: %v", ifName)
+	klog.Infof("Interface Name: %s", ifName)
+
 	err = enableIPV6LinkLocal(ifName)
 	if err != nil {
 		vsp.log.Error(err, "Error occurred in enabling IPv6 Link local Address: %v")

--- a/internal/daemon/vendor-specific-plugins/marvell/main.go
+++ b/internal/daemon/vendor-specific-plugins/marvell/main.go
@@ -396,6 +396,14 @@ func getInterfaceName(deviceID string) (string, error) {
 // enableIPV6LinkLocal function to enable the IPv6 Link Local Address on the given Interface Name
 // It will return the error
 func enableIPV6LinkLocal(interfaceName string) error {
+	// Tell NetworkManager to not manage our interface.
+	err1 := exec.Command("nsenter", "-t", "1", "-m", "-u", "-n", "-i", "--", "nmcli", "device", "set", interfaceName, "managed", "no").Run()
+	if err1 != nil {
+		// This error may be fine. Maybe our host doesn't even run
+		// NetworkManager. Ignore.
+		klog.Infof("nmcli device set %s managed no failed with error %v", interfaceName, err1)
+	}
+
 	// Ensure to set addrgenmode and toggle link state (which can result in creating
 	// the IPv6 link local address. Ignore errors here.
 	exec.Command("ip", "link", "set", interfaceName, "addrgenmode", "eui64").Run()


### PR DESCRIPTION
This is a re-creation of https://github.com/openshift/dpu-operator/pull/262

The patches are the same. This is a continuation of 262, and only exists to workaround a glitch in CI.

Consider it the same PR, and continue discussion here.