### PR TITLE
IIC 294 - Move to idpf v6.12

### DIFF
--- a/hack/cluster-configs/config-dpu.yaml
+++ b/hack/cluster-configs/config-dpu.yaml
@@ -4,7 +4,7 @@ clusters:
     ingress_vip: "192.168.122.101"
     network_api_port: "eno12409"
     kind: "iso"
-    install_iso: "{{iso_server()}}/RHEL-9.6.0-20250107.2-aarch64-dvd1-w-kickstart.iso"
+    install_iso: "{{iso_server()}}/RHEL-9.6.0-20250130.2-aarch64-dvd1-w-kickstart.iso"
     masters:
     - name: "{{worker_number(0)}}-acc"
       node: "localhost"


### PR DESCRIPTION
Bump RHEL to include idpf 6.12

With the move to idpf 6.12 we do not expect the host idpf to crash. It should be able to recover in the event the card reboots.

Move to latest RHEL 9.6 and remove WA in lockstep