### PR TITLE
[th/marvell-bmc-user] cluster-configs: remove the bmc.user from "config-dpu.yaml" (2)

### DIFF
--- a/hack/cluster-configs/config-dpu.yaml
+++ b/hack/cluster-configs/config-dpu.yaml
@@ -11,7 +11,6 @@ clusters:
       kind: "dpu"
       bmc:
         url: "{{bmc_hostname(0)}}"
-        user: "root"
       host_side_bmc: "{{bmc(0)}}"
       ip: "172.16.3.16"
       mac: "{{DPU_mac_address(0)}}"


### PR DESCRIPTION
In CDA, internally the bmc.user already defaults to "root". So setting this had no real effect. Using "root" is suitable for the IPU clusters that we have.

Btw, note that CDA's ipu.IPUBMC() also can hack certain passwords to another hard coded value. So it's not the case that CDA always honors the settings from the cluster config yaml.

The problem is that we want that this same config also works against Marvell DPUs. In such clusters, the "BMC" is the x86_64 host that contains the DPU. We usually expect that host to be an OCP node and run CoreOS. As such, we assume that we can ssh into the host using "core" user and public key authentication.

Note that currently the bmc.user cannot be templated from the google spreadsheet. To make "hack/cluster-configs/config-dpu.yaml" work with Marvell DPUs, CDA overwrites the "bmc.user" setting when deploying a Marvell DPU and always uses "core".

Drop the bmc.user setting there, because it is confusing when CDA (for Marvell DPU) ignores the value here.

And it's also not necessary, because CDA's clustersConfig class will fill in "root" as default anyway.