### PR TITLE
[th/cluster-config-network-port] cluster-configs: set "network_api_port" for ISO clusters from cluster info

### DIFF
--- a/hack/cluster-configs/config-dpu.yaml
+++ b/hack/cluster-configs/config-dpu.yaml
@@ -2,7 +2,7 @@ clusters:
   - name : "iso_cluster"
     api_vip: "192.168.122.99"
     ingress_vip: "192.168.122.101"
-    network_api_port: "eno12409"
+    network_api_port: "{{secondary_network_port()}}"
     kind: "iso"
     install_iso: "{{iso_server()}}/RHEL-9.6.0-20250130.2-aarch64-dvd1-w-kickstart.iso"
     masters:


### PR DESCRIPTION
We want to use "hack/cluster-configs/config-dpu.yaml" to deploy also
our Marvell DPUs.

In our clusters, we will need "network_api_port" set to "eno2" instead
of "eno12409".

Get the value from the cluster info in the Google spread sheet.
