### PR TITLE
[th/config-install-iso] config: update install_iso for "config-dpu.yaml"

### DIFF
--- a/hack/cluster-configs/config-dpu.yaml
+++ b/hack/cluster-configs/config-dpu.yaml
@@ -4,7 +4,7 @@ clusters:
     ingress_vip: "192.168.122.101"
     network_api_port: "{{secondary_network_port()}}"
     kind: "iso"
-    install_iso: "{{iso_server()}}/RHEL-9.6.0-20250130.2-aarch64-dvd1-w-kickstart.iso"
+    install_iso: "{{iso_server()}}/RHEL-9.6.0-20250212.4-aarch64-dvd1-w-kickstart.iso"
     masters:
     - name: "{{worker_number(0)}}-acc"
       node: "localhost"


### PR DESCRIPTION
We need a more recent rhel-9.6 kernel for Marvell DPU (and host side). Update the iso.