### PR TITLE
Set Owner Reference in VSP

### DIFF
--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -18,6 +18,7 @@ import (
 	configv1 "github.com/openshift/dpu-operator/api/v1"
 	"github.com/openshift/dpu-operator/internal/scheme"
 	"github.com/openshift/dpu-operator/internal/testutils"
+	"github.com/openshift/dpu-operator/pkgs/vars"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -72,7 +73,7 @@ var _ = g.Describe("Dpu side", g.Ordered, func() {
 	g.It("Should create a pod when creating an SFC", func() {
 		nfName := "example-nf"
 		nfImage := "example-nf-image-url"
-		ns := "openshift-dpu-operator"
+		ns := vars.Namespace
 
 		Eventually(func() bool {
 			return testutils.GetPod(dpuSideClient, nfName, ns) == nil

--- a/internal/controller/bindata/daemon/04.daemon_cluster_role.yaml
+++ b/internal/controller/bindata/daemon/04.daemon_cluster_role.yaml
@@ -15,3 +15,18 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - dpuoperatorconfigs
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - dpuoperatorconfigs/finalizers
+  verbs:
+  - update

--- a/internal/controller/bindata/daemon/99.daemonset.yaml
+++ b/internal/controller/bindata/daemon/99.daemonset.yaml
@@ -28,12 +28,18 @@ spec:
           privileged: true
         imagePullPolicy: {{.ImagePullPolicy}}
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: K8S_NODE
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
         - name: NAMESPACE
-          value: {{.Namespace}}
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: IntelVspImage
           value: {{.IntelVspImage}}
         - name: MarvellVspImage

--- a/internal/controller/dpuoperatorconfig_controller.go
+++ b/internal/controller/dpuoperatorconfig_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/dpu-operator/api/v1"
 	"github.com/openshift/dpu-operator/pkgs/render"
+	"github.com/openshift/dpu-operator/pkgs/vars"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -113,7 +114,7 @@ func (r *DpuOperatorConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 func (r *DpuOperatorConfigReconciler) createCommonData(cfg *configv1.DpuOperatorConfig) map[string]string {
 	// All the CRs will be in the same namespace as the operator config
 	data := map[string]string{
-		"Namespace":              "openshift-dpu-operator",
+		"Namespace":              vars.Namespace,
 		"ImagePullPolicy":        r.imagePullPolicy,
 		"Mode":                   "auto",
 		"DpuOperatorDaemonImage": r.dpuDaemonImage,

--- a/internal/controller/dpuoperatorconfig_controller_test.go
+++ b/internal/controller/dpuoperatorconfig_controller_test.go
@@ -31,12 +31,13 @@ import (
 
 	"github.com/openshift/dpu-operator/internal/daemon/plugin"
 	"github.com/openshift/dpu-operator/internal/testutils"
+	"github.com/openshift/dpu-operator/pkgs/vars"
 
 	configv1 "github.com/openshift/dpu-operator/api/v1"
 )
 
 var (
-	testNamespace              = "openshift-dpu-operator"
+	testNamespace              = vars.Namespace
 	testDpuOperatorConfigName  = "default"
 	testDpuOperatorConfigKind  = "DpuOperatorConfig"
 	testDpuDaemonName          = "dpu-daemon"

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -102,7 +102,7 @@ func (d *Daemon) Stop() {
 
 func (d *Daemon) createDaemon(dpuMode bool, config *rest.Config, vspImages map[string]string, client client.Client) (SideManager, error) {
 	platform := platform.NewPlatformInfo()
-	plugin, err := platform.VspPlugin(dpuMode, vspImages, client)
+	plugin, err := platform.NewVspPlugin(dpuMode, vspImages, client)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/daemon/dpusidemanager.go
+++ b/internal/daemon/dpusidemanager.go
@@ -19,6 +19,7 @@ import (
 	sfcreconciler "github.com/openshift/dpu-operator/internal/daemon/sfc-reconciler"
 	"github.com/openshift/dpu-operator/internal/scheme"
 	"github.com/openshift/dpu-operator/internal/utils"
+	"github.com/openshift/dpu-operator/pkgs/vars"
 	pb "github.com/opiproject/opi-api/network/evpn-gw/v1alpha1/gen/go"
 	"google.golang.org/grpc"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
@@ -244,7 +245,7 @@ func (d *DpuSideManager) setupReconcilers() {
 			Scheme: scheme.Scheme,
 			NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 				opts.DefaultNamespaces = map[string]cache.Config{
-					"openshift-dpu-operator": {},
+					vars.Namespace: {},
 				}
 				return cache.New(config, opts)
 			},

--- a/internal/daemon/dpusidemanager_test.go
+++ b/internal/daemon/dpusidemanager_test.go
@@ -69,9 +69,10 @@ var _ = g.Describe("DPU side maanger", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
-		dpuPlugin := plugin.NewGrpcPlugin(true,
+		dpuPlugin, err := plugin.NewGrpcPlugin(true,
 			client,
 			plugin.WithPathManager(pathManager))
+		Expect(err).NotTo(HaveOccurred())
 		dpuDaemon = NewDpuSideManger(dpuPlugin, config, WithPathManager(pathManager))
 
 		dpuListen, err := dpuDaemon.Listen()

--- a/internal/daemon/hostsidemanager.go
+++ b/internal/daemon/hostsidemanager.go
@@ -17,6 +17,7 @@ import (
 	sfcreconciler "github.com/openshift/dpu-operator/internal/daemon/sfc-reconciler"
 	"github.com/openshift/dpu-operator/internal/scheme"
 	"github.com/openshift/dpu-operator/internal/utils"
+	"github.com/openshift/dpu-operator/pkgs/vars"
 	pb "github.com/opiproject/opi-api/network/evpn-gw/v1alpha1/gen/go"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -312,7 +313,7 @@ func (d *HostSideManager) setupReconcilers() {
 			Scheme: scheme.Scheme,
 			NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 				opts.DefaultNamespaces = map[string]cache.Config{
-					"openshift-dpu-operator": {},
+					vars.Namespace: {},
 				}
 				return cache.New(config, opts)
 			},

--- a/internal/daemon/plugin/vendorplugin.go
+++ b/internal/daemon/plugin/vendorplugin.go
@@ -78,7 +78,7 @@ type GrpcPlugin struct {
 func NewVspTemplateVars() VspTemplateVars {
 	return VspTemplateVars{
 		VendorSpecificPluginImage: "",
-		Namespace:                 "openshift-dpu-operator",
+		Namespace:                 vars.Namespace,
 		ImagePullPolicy:           "Always",
 		Command:                   "[ ]",
 		Args:                      "[ ]",

--- a/internal/daemon/plugin/vendorplugin.go
+++ b/internal/daemon/plugin/vendorplugin.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	pb "github.com/openshift/dpu-operator/dpu-api/gen"
+	"github.com/openshift/dpu-operator/internal/scheme"
 	"github.com/openshift/dpu-operator/internal/utils"
 	"github.com/openshift/dpu-operator/pkgs/render"
 	opi "github.com/opiproject/opi-api/network/evpn-gw/v1alpha1/gen/go"
@@ -136,7 +137,7 @@ func (gp *GrpcPlugin) deployVsp() {
 
 	if vspImage != "" {
 		gp.log.Info("Deploying VSP", "vspImage", vspImage, "command", gp.vsp.Command, "args", gp.vsp.Args)
-		err := render.ApplyAllFromBinData(gp.log, "vsp-ds", gp.vsp.ToMap(), binData, gp.k8sClient, nil, nil)
+		err := render.ApplyAllFromBinData(gp.log, "vsp-ds", gp.vsp.ToMap(), binData, gp.k8sClient, nil, scheme.Scheme)
 		if err != nil {
 			gp.log.Error(err, "Failed to start vendor plugin container", "vspImage", gp.vsp.VendorSpecificPluginImage)
 		}

--- a/internal/daemon/sfc-reconciler/sfc.go
+++ b/internal/daemon/sfc-reconciler/sfc.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/dpu-operator/api/v1"
+	"github.com/openshift/dpu-operator/pkgs/vars"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -33,7 +34,7 @@ func networkFunctionPod(name string, image string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: "openshift-dpu-operator",
+			Namespace: vars.Namespace,
 			Annotations: map[string]string{
 				"k8s.v1.cni.cncf.io/networks": "dpunfcni-conf, dpunfcni-conf",
 			},

--- a/internal/platform/ipu.go
+++ b/internal/platform/ipu.go
@@ -57,7 +57,7 @@ func (pi *IntelDetector) IsDpuPlatform() (bool, error) {
 	return false, nil
 }
 
-func (pi *IntelDetector) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client) *plugin.GrpcPlugin {
+func (pi *IntelDetector) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client) (*plugin.GrpcPlugin, error) {
 	template_vars := plugin.NewVspTemplateVars()
 	template_vars.VendorSpecificPluginImage = vspImages[plugin.VspImageIntel]
 	template_vars.Command = `[ "/usr/bin/ipuplugin" ]`

--- a/internal/platform/marvell-dpu.go
+++ b/internal/platform/marvell-dpu.go
@@ -51,7 +51,7 @@ func (pi *MarvellDetector) IsDpuPlatform() (bool, error) {
 	return false, nil
 }
 
-func (pi *MarvellDetector) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client) *plugin.GrpcPlugin {
+func (pi *MarvellDetector) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client) (*plugin.GrpcPlugin, error) {
 	template_vars := plugin.NewVspTemplateVars()
 	template_vars.VendorSpecificPluginImage = vspImages[plugin.VspImageMarvell]
 	template_vars.Command = `[ "/vsp-mrvl" ]`

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -16,7 +16,7 @@ type PlatformInfoProvider interface {
 
 type VendorDetector interface {
 	IsDpuPlatform() (bool, error)
-	VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client) *plugin.GrpcPlugin
+	VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client) (*plugin.GrpcPlugin, error)
 	IsDPU(pci ghw.PCIDevice) (bool, error)
 	GetVendorName() string
 }
@@ -47,7 +47,12 @@ func (pi *PlatformInfo) NewVspPlugin(dpuMode bool, vspImages map[string]string, 
 	if err != nil {
 		return nil, err
 	}
-	return detector.VspPlugin(dpuMode, vspImages, client), nil
+	vspPlugin, err := detector.VspPlugin(dpuMode, vspImages, client)
+	if err != nil {
+		return nil, errors.Errorf("Error encountered when deploying VspPlugin: %v", err)
+	}
+
+	return vspPlugin, nil
 }
 
 func (pi *PlatformInfo) Getvendorname() (string, error) {

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -35,6 +35,21 @@ func NewPlatformInfo() *PlatformInfo {
 	}
 }
 
+func (pi *PlatformInfo) NewVspPlugin(dpuMode bool, vspImages map[string]string, client client.Client) (*plugin.GrpcPlugin, error) {
+	var detector VendorDetector
+	var err error
+
+	if dpuMode {
+		detector, err = pi.detectDpuPlatform(true)
+	} else {
+		detector, err = pi.detectDpuSystem(true)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return detector.VspPlugin(dpuMode, vspImages, client), nil
+}
+
 func (pi *PlatformInfo) Getvendorname() (string, error) {
 	klog.Infof("Detecting  Platform is DPU or not")
 	for _, detector := range pi.Detectors {
@@ -169,19 +184,4 @@ func (pi *PlatformInfo) detectDpuSystem(required bool) (VendorDetector, error) {
 		return nil, nil
 	}
 	return detectors[0], nil
-}
-
-func (pi *PlatformInfo) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client) (*plugin.GrpcPlugin, error) {
-	var detector VendorDetector
-	var err error
-
-	if dpuMode {
-		detector, err = pi.detectDpuPlatform(true)
-	} else {
-		detector, err = pi.detectDpuSystem(true)
-	}
-	if err != nil {
-		return nil, err
-	}
-	return detector.VspPlugin(dpuMode, vspImages, client), nil
 }

--- a/internal/scheme/scheme.go
+++ b/internal/scheme/scheme.go
@@ -17,7 +17,6 @@ func init() {
 	utilruntime.Must(corev1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(v1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme.Scheme))
-	utilruntime.Must(configv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(netattdefv1.AddToScheme(scheme.Scheme))
 	//+kubebuilder:scaffold:scheme
 }

--- a/internal/testutils/kindcluster.go
+++ b/internal/testutils/kindcluster.go
@@ -20,12 +20,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
+	"github.com/openshift/dpu-operator/pkgs/vars"
 	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 	"sigs.k8s.io/kind/pkg/cluster"
 )
 
 var (
-	testNamespace             = "openshift-dpu-operator"
+	testNamespace             = vars.Namespace
 	testDpuOperatorConfigName = "default"
 	testDpuOperatorConfigKind = "DpuOperatorConfig"
 	testDpuDaemonName         = "dpu-daemon"

--- a/pkgs/vars/vars.go
+++ b/pkgs/vars/vars.go
@@ -1,0 +1,7 @@
+package vars
+
+var (
+	Namespace = "openshift-dpu-operator"
+
+	DpuOperatorConfigName = "dpu-operator-config"
+)


### PR DESCRIPTION
Set vsp owner reference to dpuOperatorConfig

We want the vsp daemonset to be owned by some resource such that the vsp will be garbage collected properly.

Ideally this would be the daemon or dpu-daemon daemonset, but kubernetes does not allow pods or daemonsets to own other controllers.

A good step in the right direction is to have the vsp owned by the same custom resource that owns the dpu daemon.

A potenital next step might be to add an additional manager for coordinating deployment of the vsp.