### PR TITLE
tft: disable hwol plugin

### DIFF
--- a/hack/cluster-configs/ocp-tft-config.yaml
+++ b/hack/cluster-configs/ocp-tft-config.yaml
@@ -17,8 +17,6 @@ tft:
         client:
           - name: "$worker"
             sriov: "true"
-        plugins:
-          - name: validate_offload
         secondary_network_nad: "default-sriov-net"
         resource_name: "openshift.io/dpu"
 kubeconfig: "/root/kubeconfig.ocpcluster"


### PR DESCRIPTION
We are not enabling ovs-hwol, there is no reason to be running this plugin.