### PR TITLE
Marvell: Add support for default data path in VSP

### DIFF
--- a/internal/daemon/plugin/bindata/vsp-ds/99.vendor-plugin-daemonset.yaml
+++ b/internal/daemon/plugin/bindata/vsp-ds/99.vendor-plugin-daemonset.yaml
@@ -27,6 +27,9 @@ spec:
         command: {{.Command}}
         args: {{.Args}}
         volumeMounts:
+        - mountPath: /host
+          mountPropagation: Bidirectional
+          name: host-root
         - mountPath: /var/run/
           name: vendor-plugin-sock
         - mountPath: /opt/p4/p4-cp-nws/var
@@ -53,3 +56,7 @@ spec:
           path: /var/run/
           type: ""
         name: vendor-plugin-sock
+      - hostPath:
+          path: /
+          type: ""
+        name: host-root

--- a/internal/daemon/vendor-specific-plugins/marvell/main.go
+++ b/internal/daemon/vendor-specific-plugins/marvell/main.go
@@ -39,7 +39,7 @@ const (
 	NoOfPortPairs  int    = 2
 	IPv6AddrDpu    string = "fe80::1"
 	IPv6AddrHost   string = "fe80::2"
-	DataPlaneType  string = "debug"
+	DataPlaneType  string = "ovs"
 	NumPFs         int    = 1
 	PFID           int    = 0
 	isDPDK         bool   = false
@@ -273,10 +273,11 @@ func (vsp *mrvlVspServer) getVFDetails(BridgePortName string) (string, string, e
 	if err != nil {
 		return "", "", err
 	}
-	vfId, err := strconv.Atoi(matches[1])
+	vfId, err := strconv.Atoi(matches[2])
 	if err != nil {
 		return "", "", err
 	}
+	vfId = vfId + 1 // VF Id 0 is for PF
 	klog.Infof("Mapped VF for PFID: %d, VFID: %d, NumPFs: %d", pfid, vfId, NumPFs)
 	vfPciAddress, err := mrvlutils.Mapped_VF(NumPFs, PFID, vfId) // TODO: Get PF Count=1 and PF ID=0
 	if err != nil {
@@ -303,7 +304,7 @@ func (vsp *mrvlVspServer) getVFDetails(BridgePortName string) (string, string, e
 // CreateBridgePort function to create a bridge port with the given context and CreateBridgePortRequest
 // It will return the BridgePort and error
 func (vsp *mrvlVspServer) CreateBridgePort(ctx context.Context, in *opi.CreateBridgePortRequest) (*opi.BridgePort, error) {
-	klog.Infof("Received CreateBridgePort() request: BridgePortId: %v, BridgePortId: %v", in.BridgePortId, in.BridgePortId)
+	klog.Infof("Received CreateBridgePort() request: BridgePortId: %v, BridgePort: %v", in.BridgePortId, in.BridgePort)
 	portName := in.BridgePort.Name
 	vfName, vfPCIAddress, err := vsp.getVFDetails(portName)
 	if err != nil {

--- a/internal/daemon/vendor-specific-plugins/marvell/mrvl-utils/mrvlutils.go
+++ b/internal/daemon/vendor-specific-plugins/marvell/mrvl-utils/mrvlutils.go
@@ -56,7 +56,7 @@ func Mapped_VF(pf_count int, pfid int, vfid int) (string, error) {
 	}
 	dpu_vfid := pf_count*vfid + pfid
 	size := len(list) - 1
-	if dpu_vfid >= size {
+	if dpu_vfid > size {
 		return "", errors.New("mapped VF out of bounds")
 	}
 

--- a/internal/daemon/vendor-specific-plugins/marvell/ovs-dp/ovsdp.go
+++ b/internal/daemon/vendor-specific-plugins/marvell/ovs-dp/ovsdp.go
@@ -44,11 +44,11 @@ func (ovsdp *OvsDP) AddPortToDataPlane(bridgeName string, portName string, vfPCI
 
 	if isDPDK {
 		ovsdp.log.Info("Adding DPDK Port to Bridge", "PortName", portName, "VFPCIAddress", vfPCIAddres)
-		cmd = exec.Command("ovs-vsctl", "--may-exist", "add-port", bridgeName, portName, "--", "set", "Interface", portName, "type=dpdk", fmt.Sprintf("options:dpdk-devargs=%s", vfPCIAddres))
+		cmd = exec.Command("chroot", "/host", "ovs-vsctl", "--may-exist", "add-port", bridgeName, portName, "--", "set", "Interface", portName, "type=dpdk", fmt.Sprintf("options:dpdk-devargs=%s", vfPCIAddres))
 
 	} else {
 		ovsdp.log.Info("Adding Port to Bridge", "PortName", portName)
-		cmd = exec.Command("ovs-vsctl", "--may-exist", "add-port", bridgeName, portName)
+		cmd = exec.Command("chroot", "/host", "ovs-vsctl", "--may-exist", "add-port", bridgeName, portName)
 
 	}
 	return cmd.Run()
@@ -57,19 +57,19 @@ func (ovsdp *OvsDP) AddPortToDataPlane(bridgeName string, portName string, vfPCI
 // ovs-vsctl command to delete dpdk-port from bridge
 func (ovsdp *OvsDP) DeletePortFromDataPlane(bridgeName string, portName string) error {
 	ovsdp.log.Info("Deleting Port from Bridge", "PortName", portName)
-	cmd := exec.Command("ovs-vsctl", "del-port", bridgeName, portName)
+	cmd := exec.Command("chroot", "/host", "ovs-vsctl", "del-port", bridgeName, portName)
 	return cmd.Run()
 }
 
 // ovs-vsctl command to delete ovs bridge
 func (ovsdp *OvsDP) DeleteDataplane(bridgeName string) error {
-	cmd := exec.Command("ovs-vsctl", "del-br", bridgeName)
+	cmd := exec.Command("chroot", "/host", "ovs-vsctl", "del-br", bridgeName)
 	return cmd.Run()
 }
 
 // ovs-vsctl command to create bridge
 func createBridge(bridgeName string) error {
-	cmd := exec.Command("ovs-vsctl", "--may-exist", "add-br", bridgeName, "--", "set", "bridge", bridgeName, "datapath_type=netdev")
+	cmd := exec.Command("chroot", "/host", "ovs-vsctl", "--may-exist", "add-br", bridgeName, "--", "set", "bridge", bridgeName, "datapath_type=netdev")
 	return cmd.Run()
 }
 
@@ -100,7 +100,7 @@ func (ovsdp *OvsDP) InitDataPlane(bridgeName string) error {
 
 // ReadPortFromBridge reads all the ports from the bridge
 func (ovsdp *OvsDP) ReadAllPortFromDataPlane(bridgeName string) (string, error) {
-	cmd := exec.Command("ovs-vsctl", "--may-exist", "list-ports", bridgeName)
+	cmd := exec.Command("chroot", "/host", "ovs-vsctl", "--may-exist", "list-ports", bridgeName)
 	out, err := cmd.Output()
 	if err != nil {
 		ovsdp.log.Error(err, "Error occurred in reading ports from Bridge")


### PR DESCRIPTION
Mounted required directories in `vsp.yaml` to enable the default data path as ovs bridge in the Marvell VSP