### PR TITLE
[th/tft-output] tft: fix script to only evaluate latest test run

### DIFF
--- a/hack/traffic_flow_tests.sh
+++ b/hack/traffic_flow_tests.sh
@@ -27,6 +27,8 @@ temp_file=$(mktemp)
 
 envsubst < ../hack/cluster-configs/ocp-tft-config.yaml > $temp_file
 
-./tft.py -v debug "$temp_file"
+OUTPUT_BASE="./ft-logs/result-$(date '+%Y%m%d-%H%M%S.%4N-')"
 
-./print_results.py ft-logs/*.json
+./tft.py -v debug --output-base "$OUTPUT_BASE" "$temp_file"
+
+./print_results.py "$OUTPUT_BASE"*.json


### PR DESCRIPTION
On Jenkins, the workspace gets wiped on each run, so the "ft-logs" directory is empty and there is no problem.

However, it's also useful to manually access the cluster and run `make traffic-flow-tests` (or a full `make e2e-test`). In that case, the result files pile up and "ft-logs/*.json" also evaluates past result files.

Fix that by using the "--output-base" parameter, which exists for this case.