### PR TITLE
Extend E2E test suite to validate Network Functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,16 @@ test: podman-check manifests generate fmt vet envtest ginkgo
 .PHONY: fast-test
 fast-test: envtest ginkgo
 	FAST_TEST=true KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) $(if $(TEST_FOCUS),-focus $(TEST_FOCUS),) ./internal/... ./pkgs/... ./api/v1/... -coverprofile cover.out
-##@ Build
+
+# Set default values for environment variables for the external client in e2e-test-suite
+NF_INGRESS_IP ?= 10.20.30.2
+EXTERNAL_CLIENT_DEV ?= eno12409
+EXTERNAL_CLIENT_IP ?= 10.20.30.100
+
+export NF_INGRESS_IP
+export EXTERNAL_CLIENT_DEV
+export EXTERNAL_CLIENT_IP
+
 .PHONY: e2e-test-suite
 e2e-test-suite: envtest ginkgo
 	FAST_TEST=true KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) $(if $(TEST_FOCUS),-focus $(TEST_FOCUS),) ./e2e_test/... -coverprofile cover.out

--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -9,6 +9,8 @@ import (
 	g "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -19,8 +21,8 @@ import (
 	"github.com/openshift/dpu-operator/internal/scheme"
 	"github.com/openshift/dpu-operator/internal/testutils"
 	"github.com/openshift/dpu-operator/pkgs/vars"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -31,25 +33,18 @@ var (
 	cfg     *rest.Config
 	testEnv *envtest.Environment
 	// TODO: reduce to 2 seconds
-	timeout  = 2 * time.Minute
-	interval = 1 * time.Second
-	nfImage  = "ghcr.io/ovn-kubernetes/kubernetes-traffic-flow-tests:latest"
-	nfName   = "test-nf"
-	sfcName  = "sfc-test"
+	timeout         = 2 * time.Minute
+	interval        = 1 * time.Second
+	nfImage         = "ghcr.io/ovn-kubernetes/kubernetes-traffic-flow-tests:latest"
+	nfName          = "test-nf"
+	sfcName         = "sfc-test"
+	secondaryNetDev = "net1"
 )
 
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(g.Fail)
 
 	g.RunSpecs(t, "e2e tests")
-}
-
-func testPodIsRunning(c client.Client, podName string, podNamespace string) bool {
-	pod := testutils.GetPod(c, podName, podNamespace)
-	if pod != nil {
-		return pod.Status.Phase == corev1.PodRunning
-	}
-	return false
 }
 
 var _ = g.BeforeSuite(func() {
@@ -60,10 +55,13 @@ var _ = g.AfterSuite(func() {
 	// Nothing needed
 })
 
-var _ = g.Describe("Dpu side", g.Ordered, func() {
+var _ = g.Describe("E2E integration testing", g.Ordered, func() {
 	var (
-		dpuSideClient client.Client
-		// hostSideClient                     client.Client
+		dpuSideClient                      client.Client
+		hostSideClient                     client.Client
+		hostRestConfig                     *rest.Config
+		dpuRestConfig                      *rest.Config
+		hostClientSet                      *kubernetes.Clientset
 		restoreDpuOperatorConfigInAfterAll func()
 	)
 
@@ -75,19 +73,24 @@ var _ = g.Describe("Dpu side", g.Ordered, func() {
 	})
 
 	g.BeforeEach(func() {
+		var err error
 		cluster := testutils.CdaCluster{
 			Name:           "",
 			HostConfigPath: "hack/cluster-configs/config-dpu-host.yaml",
 			DpuConfigPath:  "hack/cluster-configs/config-dpu.yaml",
 		}
-		_, dpuConfig, err := cluster.EnsureExists()
+		hostRestConfig, dpuRestConfig, err = cluster.EnsureExists()
 		Expect(err).NotTo(HaveOccurred())
 
-		// hostSideClient, err = client.New(hostConfig, client.Options{Scheme: scheme.Scheme})
-		// Expect(err).NotTo(HaveOccurred())
-
-		dpuSideClient, err = client.New(dpuConfig, client.Options{Scheme: scheme.Scheme})
+		hostSideClient, err = client.New(hostRestConfig, client.Options{Scheme: scheme.Scheme})
 		Expect(err).NotTo(HaveOccurred())
+
+		dpuSideClient, err = client.New(dpuRestConfig, client.Options{Scheme: scheme.Scheme})
+		Expect(err).NotTo(HaveOccurred())
+
+		hostClientSet, err = kubernetes.NewForConfig(hostRestConfig)
+		Expect(err).NotTo(HaveOccurred())
+
 	})
 
 	g.AfterEach(func() {
@@ -237,7 +240,16 @@ var _ = g.Describe("Dpu side", g.Ordered, func() {
 		})
 	})
 
-	g.Context("ServiceFunctionChain", func() {
+	g.Context("When Dpu Operator components are deployed and configured", g.Ordered, func() {
+		var (
+			testPodName  = "test-pod-1"
+			testPod2Name = "test-pod-2"
+			pod1         *corev1.Pod
+			pod2         *corev1.Pod
+			pod1_ip      string
+			pod2_ip      string
+		)
+
 		sfc := &configv1.ServiceFunctionChain{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      sfcName,
@@ -252,35 +264,149 @@ var _ = g.Describe("Dpu side", g.Ordered, func() {
 				},
 			},
 		}
-		g.It("Should create a pod when creating an SFC", func() {
-			// TODO: This test has a race condition, it may pass if the pod is being created
-			Eventually(func() bool {
-				return testutils.GetPod(dpuSideClient, nfName, vars.Namespace) == nil
-			}, timeout, interval).Should(BeTrue())
 
-			err := dpuSideClient.Create(context.TODO(), sfc)
+		g.BeforeAll(func() {
+			nodeList, err := testutils.GetDPUNodes(hostSideClient)
 			Expect(err).NotTo(HaveOccurred())
+			pod := testutils.NewTestPod(testPodName, nodeList[0].Name)
+			pod2 := testutils.NewTestPod(testPod2Name, nodeList[0].Name)
 
-			podList := &corev1.PodList{}
-			err = dpuSideClient.List(context.TODO(), podList, client.InNamespace(vars.Namespace))
+			err = hostSideClient.Create(context.TODO(), pod)
 			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(func() bool {
-				pod := testutils.GetPod(dpuSideClient, nfName, vars.Namespace)
-				if pod != nil {
-					return pod.Spec.Containers[0].Image == nfImage && pod.Status.Phase == corev1.PodRunning
-				}
-				return false
-			}, timeout, interval).Should(BeTrue())
+			err = hostSideClient.Create(context.TODO(), pod2)
+			Expect(err).NotTo(HaveOccurred())
 		})
-		g.It("Should delete the network function pod when deleting an SFC", func() {
-			err := dpuSideClient.Delete(context.TODO(), sfc)
-			Expect(err).NotTo(HaveOccurred())
-			fmt.Println("Finishing up")
 
+		g.It("Should be able to start host workload pods", func() {
+			fmt.Println("Creating workload pods")
 			Eventually(func() bool {
-				return testutils.GetPod(dpuSideClient, nfName, vars.Namespace) == nil
-			}, timeout, interval).Should(BeTrue())
+				return testutils.PodIsRunning(hostSideClient, testPodName, "default")
+			}, testutils.TestAPITimeout*45, testutils.TestRetryInterval).Should(BeTrue(), "Pod did not become running in expected time")
+			Eventually(func() bool {
+				return testutils.PodIsRunning(hostSideClient, testPod2Name, "default")
+			}, testutils.TestAPITimeout*45, testutils.TestRetryInterval).Should(BeTrue(), "Pod did not become running in expected time")
+			fmt.Println("Workload pods reached Ready state")
+
+		})
+		g.It("Should be able to pass traffic between workload pods", func() {
+			var err error
+			pod1 = testutils.GetPod(hostSideClient, testPodName, "default")
+			Expect(pod1).NotTo(BeNil(), "Unable to retrieve pod1")
+			pod2 = testutils.GetPod(hostSideClient, testPod2Name, "default")
+			Expect(pod2).NotTo(BeNil(), "Unable to retrieve pod1")
+
+			pod1_ip, err = testutils.GetSecondaryNetworkIP(pod1, secondaryNetDev)
+			Expect(err).NotTo(HaveOccurred())
+			pod2_ip, err = testutils.GetSecondaryNetworkIP(pod2, secondaryNetDev)
+			Expect(err).NotTo(HaveOccurred())
+			fmt.Printf("pod1 ip: %s\n pod2 ip: %s\n", pod1_ip, pod2_ip)
+
+			// Ping workload pod 2 from pod 1
+			fmt.Println("Testing pod-to-pod connectivity")
+			Eventually(func() bool {
+				out, err := testutils.ExecInPod(hostClientSet, hostRestConfig, pod1, fmt.Sprintf("ping -c 4 %s", pod2_ip))
+				if err != nil {
+					fmt.Printf("Ping failed: %v\n%s\n", err, out)
+				}
+				fmt.Printf("pod1 -> pod2 ping: %s\n", out)
+				return err == nil
+			}, testutils.TestAPITimeout*15, testutils.TestRetryInterval).Should(BeTrue(), "%s failed to reach %s via ping", pod1.Name, pod2.Name)
+
+			// Ping workload pod 1 from pod 2
+			Eventually(func() bool {
+				out, err := testutils.ExecInPod(hostClientSet, hostRestConfig, pod2, fmt.Sprintf("ping -c 4 %s", pod1_ip))
+				if err != nil {
+					fmt.Printf("Ping failed: %v\n%s\n", err, out)
+				}
+				fmt.Printf("pod2 -> pod1 ping: %s\n", out)
+				return err == nil
+			}, testutils.TestAPITimeout*15, testutils.TestRetryInterval).Should(BeTrue(), "%s failed to reach %s via ping", pod1.Name, pod2.Name)
+		})
+		g.Context("ServiceFunctionChain", func() {
+			g.It("Should create a pod when creating an SFC", func() {
+				// TODO: This test has a race condition, it may pass if the pod is being created
+				Eventually(func() bool {
+					return testutils.GetPod(dpuSideClient, nfName, vars.Namespace) == nil
+				}, timeout, interval).Should(BeTrue())
+
+				fmt.Println("Creating test SFC")
+				err := dpuSideClient.Create(context.TODO(), sfc)
+				Expect(err).NotTo(HaveOccurred())
+
+				podList := &corev1.PodList{}
+				err = dpuSideClient.List(context.TODO(), podList, client.InNamespace(vars.Namespace))
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() bool {
+					pod := testutils.GetPod(dpuSideClient, nfName, vars.Namespace)
+					if pod != nil {
+						return pod.Spec.Containers[0].Image == nfImage && pod.Status.Phase == corev1.PodRunning
+					}
+					return false
+				}, timeout, interval).Should(BeTrue())
+				fmt.Println("Nf pod successfully created")
+			})
+			g.It("Should support pod-to-pod with Network Function deployed", func() {
+				fmt.Println("Testing pod-to-pod connectivity w/ Network Function Deployed")
+				Eventually(func() bool {
+					out, err := testutils.ExecInPod(hostClientSet, hostRestConfig, pod1, fmt.Sprintf("ping -c 4 %s", pod2_ip))
+					if err != nil {
+						fmt.Printf("Ping failed: %v\n%s\n", err, out)
+					}
+					fmt.Printf("pod1 -> pod2 ping: %s\n", out)
+					return err == nil
+				}, testutils.TestAPITimeout*15, testutils.TestRetryInterval).Should(BeTrue(), "%s failed to reach %s via ping", pod1.Name, pod2.Name)
+
+				// Ping workload pod 1 from pod 2
+				Eventually(func() bool {
+					out, err := testutils.ExecInPod(hostClientSet, hostRestConfig, pod2, fmt.Sprintf("ping -c 4 %s", pod1_ip))
+					if err != nil {
+						fmt.Printf("Ping failed: %v\n%s\n", err, out)
+					}
+					fmt.Printf("pod2 -> pod1 ping: %s\n", out)
+					return err == nil
+				}, testutils.TestAPITimeout*15, testutils.TestRetryInterval).Should(BeTrue(), "%s failed to reach %s via ping", pod1.Name, pod2.Name)
+			})
+			g.It("Should delete the network function pod when deleting an SFC", func() {
+				err := dpuSideClient.Delete(context.TODO(), sfc)
+				Expect(err).NotTo(HaveOccurred())
+				fmt.Println("Finishing up")
+
+				Eventually(func() bool {
+					return testutils.GetPod(dpuSideClient, nfName, vars.Namespace) == nil
+				}, timeout, interval).Should(BeTrue())
+			})
+		})
+		g.AfterAll(func() {
+			// To maintain idempotency, make sure to clean up the SFC we created incase an earlier test failed
+			err := dpuSideClient.Delete(context.TODO(), sfc)
+			if err != nil && !errors.IsNotFound(err) {
+				fmt.Printf("Failed to delete SFC: %v\n", err)
+			}
+
+			for _, podName := range []string{testPodName, testPod2Name} {
+				err := hostSideClient.Delete(context.TODO(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      podName,
+						Namespace: "default",
+					},
+				})
+				if err != nil {
+					fmt.Printf("Failed to delete pod %s\n", podName)
+					continue
+				}
+
+				fmt.Printf("Waiting for pod %s to be fully deleted...\n", podName)
+				Eventually(func() bool {
+					pod := &corev1.Pod{}
+					err := hostSideClient.Get(context.TODO(), client.ObjectKey{
+						Name:      podName,
+						Namespace: "default",
+					}, pod)
+
+					return err != nil && errors.IsNotFound(err)
+				}, testutils.TestAPITimeout*30, testutils.TestRetryInterval).Should(BeTrue(), "Pod %s was not fully deleted in time", podName)
+			}
 		})
 	})
 })

--- a/internal/controller/dpuoperatorconfig_controller_test.go
+++ b/internal/controller/dpuoperatorconfig_controller_test.go
@@ -42,7 +42,7 @@ var (
 	testDpuOperatorConfigKind  = "DpuOperatorConfig"
 	testDpuDaemonName          = "dpu-daemon"
 	testNetworkFunctionNADDpu  = "dpunfcni-conf"
-	testNetworkFunctionNADHost = "default-sriov-net"
+	testNetworkFunctionNADHost = vars.DefaultHostNADName
 	testClusterName            = "dpu-operator-test-cluster"
 	setupLog                   = ctrl.Log.WithName("setup")
 )

--- a/internal/testutils/testcluster.go
+++ b/internal/testutils/testcluster.go
@@ -1,9 +1,20 @@
 package testutils
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/openshift/dpu-operator/pkgs/vars"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -12,7 +23,15 @@ type Cluster interface {
 	EnsureDeleted()
 }
 
-func GetPod(c client.Client, name, namespace string) *corev1.Pod {
+type NetworkStatus struct {
+	Name      string   `json:"name"`
+	Interface string   `json:"interface"`
+	IPs       []string `json:"ips"`
+	Mac       string   `json:"mac"`
+	DNS       struct{} `json:"dns"`
+}
+
+func GetPod(c client.Client, name string, namespace string) *corev1.Pod {
 	obj := client.ObjectKey{Namespace: namespace, Name: name}
 	pod := &corev1.Pod{}
 	err := c.Get(context.TODO(), obj, pod)
@@ -20,4 +39,113 @@ func GetPod(c client.Client, name, namespace string) *corev1.Pod {
 		return nil
 	}
 	return pod
+}
+
+func ExecInPod(clientset kubernetes.Interface, config *rest.Config, pod *corev1.Pod, command string) (string, error) {
+	if pod == nil {
+		return "", fmt.Errorf("pod cannot be nil")
+	}
+
+	podExecOptions := corev1.PodExecOptions{
+		Command: []string{"sh", "-c", command},
+		Stdout:  true,
+		Stderr:  true,
+		TTY:     false,
+	}
+
+	req := clientset.CoreV1().RESTClient().Post().Resource("pods").Name(pod.Name).Namespace(pod.Namespace).SubResource("exec").VersionedParams(&podExecOptions, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		return "", fmt.Errorf("failed to create SPDY executor: %w", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: io.Writer(&stdout),
+		Stderr: io.Writer(&stderr),
+	})
+	if err != nil {
+		return stderr.String(), fmt.Errorf("command execution failed: %w", err)
+	}
+
+	return stdout.String(), nil
+}
+
+func GetDPUNodes(c client.Client) ([]corev1.Node, error) {
+	nodeList := &corev1.NodeList{}
+	labelSelector := client.MatchingLabels{"dpu": "true"}
+
+	err := c.List(context.TODO(), nodeList, labelSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	return nodeList.Items, nil
+}
+
+func NewTestPod(podName string, nodeHostname string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: "default",
+			Annotations: map[string]string{
+				"k8s.v1.cni.cncf.io/networks": vars.DefaultHostNADName,
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeSelector: map[string]string{
+				"kubernetes.io/hostname": nodeHostname,
+			},
+			Containers: []corev1.Container{
+				{
+					Name:            "appcntr1",
+					Image:           "ghcr.io/ovn-kubernetes/kubernetes-traffic-flow-tests:latest",
+					ImagePullPolicy: corev1.PullAlways,
+					SecurityContext: &corev1.SecurityContext{
+						Privileged:   new(bool),
+						RunAsNonRoot: new(bool),
+						RunAsUser:    new(int64),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func PodIsRunning(c client.Client, podName string, podNamespace string) bool {
+	pod := GetPod(c, podName, podNamespace)
+	if pod != nil {
+		return pod.Status.Phase == corev1.PodRunning
+	}
+	return false
+}
+
+func GetSecondaryNetworkIP(pod *corev1.Pod, netdevName string) (string, error) {
+	annotation, exists := pod.Annotations["k8s.v1.cni.cncf.io/network-status"]
+	if !exists {
+		return "", fmt.Errorf("network-status annotation not found")
+	}
+
+	var networks []NetworkStatus
+	err := json.Unmarshal([]byte(annotation), &networks)
+	if err != nil {
+		return "", err
+	}
+
+	// Find secondary network IP
+	for _, net := range networks {
+		if net.Interface == netdevName {
+			if len(net.IPs) > 0 {
+				return net.IPs[0], nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("secondary network IP not found")
 }

--- a/pkgs/drain/drain_test.go
+++ b/pkgs/drain/drain_test.go
@@ -75,7 +75,7 @@ func ensureTestPodDeleted(c client.Client) {
 func testPodIsRunning() bool {
 	pod := testutils.GetPod(k8sClient, podName, podNamespace)
 	if pod != nil {
-		return pod.Status.Phase != corev1.PodRunning
+		return pod.Status.Phase == corev1.PodRunning
 	}
 	return false
 }

--- a/pkgs/drain/drain_test.go
+++ b/pkgs/drain/drain_test.go
@@ -157,9 +157,7 @@ var _ = Describe("Drain Interface", Ordered, func() {
 		var err error
 
 		BeforeAll(func() {
-			Eventually(func() bool {
-				return testPodIsRunning()
-			}, testutils.TestAPITimeout, testutils.TestRetryInterval).Should(BeTrue(), "Pod did not become running in expected time")
+			Eventually(testPodIsRunning, testutils.TestAPITimeout, testutils.TestRetryInterval).Should(BeTrue(), "Pod did not become running in expected time")
 
 			ctrl.Log.Info("Draining node", "nodeName", node.Name)
 			testDrainer, err = NewDrainer(restConfig)

--- a/pkgs/vars/vars.go
+++ b/pkgs/vars/vars.go
@@ -4,4 +4,6 @@ var (
 	Namespace = "openshift-dpu-operator"
 
 	DpuOperatorConfigName = "dpu-operator-config"
+
+	DefaultHostNADName = "default-sriov-net"
 )


### PR DESCRIPTION
In order to validate Network Function connectivity, we first need to validate pod-to-pod connectivity.

We will then validate SFC behavior, and validate that pod-to-pod still works once the Network Function has been created

We need to validate that Network Function l3 connectivity is working. Add the tests to validate connectivity both from Network Function to workload pod, and from external client to workload pod.

TODO: Tests assume the external client is the host running e2e-test-suite. It would be nice if an arbitrary client reachable from the DPU could be provided instead.