### PR TITLE
Provide NET_ADMIN cap to NF pod

### DIFF
--- a/internal/daemon/sfc-reconciler/sfc.go
+++ b/internal/daemon/sfc-reconciler/sfc.go
@@ -62,7 +62,7 @@ func networkFunctionPod(name string, image string) *corev1.Pod {
 						AllowPrivilegeEscalation: &falseVar,
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{"ALL"},
-							Add:  []corev1.Capability{"NET_RAW"},
+							Add:  []corev1.Capability{"NET_RAW", "NET_ADMIN"},
 						},
 					},
 				},


### PR DESCRIPTION
We automatically deploy a network attachment definition for the NF pods.

The user may want to configure a network device beyond what is done in the default nad we created. Ensure the pod has permissions so this is possible.