### PR TITLE
Pull Intel PR 365

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/golang/glog v1.2.4
 	github.com/gorilla/mux v1.8.1
-	github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250307231544-b32d7d6588f4
+	github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250314004734-6ecf80f8d0e1
 	github.com/jaypipes/ghw v0.13.1-0.20241024164530-c1bfc6e6cd6a
 	github.com/k8snetworkplumbingwg/cni-log v0.0.0-20230801160229-b6e062c9e0f2
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+h
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250307231544-b32d7d6588f4 h1:1pKvcI9HQm+UgmBqvIseVo1eXd/q1yB3970tU795ik8=
-github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250307231544-b32d7d6588f4/go.mod h1:jOw67lT03rgyqc/SOYTaptB5Gwe/oURVZ0hicFZNgmI=
+github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250314004734-6ecf80f8d0e1 h1:bwiY6H3jXfSFqWXWB4POAQHfee442lj/lNByWiSHnRk=
+github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250314004734-6ecf80f8d0e1/go.mod h1:jOw67lT03rgyqc/SOYTaptB5Gwe/oURVZ0hicFZNgmI=
 github.com/jaypipes/ghw v0.13.1-0.20241024164530-c1bfc6e6cd6a h1:orxBMCkYww7RFCk3iCDP9DC3l+yKtp4VdWtctCTyjPQ=
 github.com/jaypipes/ghw v0.13.1-0.20241024164530-c1bfc6e6cd6a/go.mod h1:F4UM7Ix55ONYwD3Lck2S4BI+hKezOwtizuJxXDFsioo=
 github.com/jaypipes/pcidb v1.0.1 h1:WB2zh27T3nwg8AE8ei81sNRb9yWBii3JGNJtT7K9Oic=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -320,7 +320,7 @@ github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.1.0
 ## explicit; go 1.18
 github.com/inconshreveable/mousetrap
-# github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250307231544-b32d7d6588f4
+# github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250314004734-6ecf80f8d0e1
 ## explicit; go 1.23.6
 github.com/intel/ipu-opi-plugins/ipu-plugin/ipuplugin/cmd
 github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/infrapod


### PR DESCRIPTION
Intel PR 365: 
Fix for GetDevices, to return PCI address for Host VFs.
Also added caching for GetDevices similar approach like marvell's vsp, so that GetDevices will return total number of Host VFs(and not what is actually available, since that is maintained by DPU code). 