### PR TITLE
Init Intel p4sdk Dockerfile

### DIFF
--- a/Dockerfile.IntelP4.rhel
+++ b/Dockerfile.IntelP4.rhel
@@ -1,0 +1,10 @@
+FROM registry.access.redhat.com/ubi9/ubi:9.5
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /
+
+COPY cmd/intelvsp/p4sdk/entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]
+

--- a/cmd/intelvsp/p4sdk/entrypoint.sh
+++ b/cmd/intelvsp/p4sdk/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Dummy entrypoint to be replaced by actual p4sdk implementation
+sleep infinity


### PR DESCRIPTION
Add a dummy Dockerfile to unblock creating the requisite metadata to onboard the p4sdk container with ART