### PR TITLE
[th/vsp-no-lib-modules] vsp: remove unused volume from "99.vendor-plugin-daemonset.yaml"

### DIFF
--- a/internal/daemon/plugin/bindata/vsp-ds/99.vendor-plugin-daemonset.yaml
+++ b/internal/daemon/plugin/bindata/vsp-ds/99.vendor-plugin-daemonset.yaml
@@ -50,10 +50,6 @@ spec:
           type: ""
         name: host-opt
       - hostPath:
-          path: /lib/modules
-          type: DirectoryOrCreate
-        name: host-libmodules
-      - hostPath:
           path: /var/run/
           type: ""
         name: vendor-plugin-sock


### PR DESCRIPTION
volume "host-libmodules" is not used, and likely it should not be used to not mix core directories of the container with directories from the host. There is already host-root path ("/host") for that.

While at it, add a tailing newline to the file. Text files without trailing newline look odd in editors.