### PR TITLE
[th/cda-options] hack: pass $CDA_OPTIONS environment to cda call

### DIFF
--- a/hack/both.sh
+++ b/hack/both.sh
@@ -6,13 +6,13 @@ cd cluster-deployment-automation
 source /tmp/cda-venv/bin/activate
 
 # Tear down any previous cluster fully
-./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy -f
+./cda.py --secret /root/pull_secret.json $CDA_OPTIONS ../hack/cluster-configs/config-dpu-host.yaml deploy -f
 
 parallel -u --halt 2 ::: \
-  "./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu.yaml deploy && echo 'Successfully Deployed ISO Cluster'" \
-  "./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy --steps pre,masters && echo 'Successfully Deployed DPU host Cluster'"
+  "./cda.py --secret /root/pull_secret.json \$CDA_OPTIONS ../hack/cluster-configs/config-dpu.yaml deploy && echo 'Successfully Deployed ISO Cluster'" \
+  "./cda.py --secret /root/pull_secret.json \$CDA_OPTIONS ../hack/cluster-configs/config-dpu-host.yaml deploy --steps pre,masters && echo 'Successfully Deployed DPU host Cluster'"
 
-./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy --steps workers,post && echo "Successfully Deployed DPU host Cluster"
+./cda.py --secret /root/pull_secret.json $CDA_OPTIONS ../hack/cluster-configs/config-dpu-host.yaml deploy --steps workers,post && echo "Successfully Deployed DPU host Cluster"
 
 # WA to avoid starting the e2e-tests before CRDs are fully installed
 sleep 60

--- a/hack/dpu_deploy.sh
+++ b/hack/dpu_deploy.sh
@@ -6,9 +6,9 @@ cd cluster-deployment-automation
 source /tmp/cda-venv/bin/activate
 
 # Tear down any previous cluster fully
-./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy -f
+./cda.py --secret /root/pull_secret.json $CDA_OPTIONS ../hack/cluster-configs/config-dpu-host.yaml deploy -f
 
-./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu.yaml deploy
+./cda.py --secret /root/pull_secret.json $CDA_OPTIONS ../hack/cluster-configs/config-dpu.yaml deploy
 
 ret=$?
 if [ $ret == 0 ]; then

--- a/hack/dpu_deploy_post.sh
+++ b/hack/dpu_deploy_post.sh
@@ -5,7 +5,7 @@ set -e
 cd cluster-deployment-automation
 source /tmp/cda-venv/bin/activate
 
-./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu.yaml deploy -s post
+./cda.py --secret /root/pull_secret.json $CDA_OPTIONS ../hack/cluster-configs/config-dpu.yaml deploy -s post
 
 ret=$?
 if [ $ret == 0 ]; then

--- a/hack/ipu_host_deploy.sh
+++ b/hack/ipu_host_deploy.sh
@@ -5,7 +5,7 @@ set -e
 cd cluster-deployment-automation
 source /tmp/cda-venv/bin/activate
 
-./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy
+./cda.py --secret /root/pull_secret.json $CDA_OPTIONS ../hack/cluster-configs/config-dpu-host.yaml deploy
 
 ret=$?
 if [ $ret == 0 ]; then

--- a/hack/ipu_host_deploy_post.sh
+++ b/hack/ipu_host_deploy_post.sh
@@ -5,7 +5,7 @@ set -e
 cd cluster-deployment-automation
 source /tmp/cda-venv/bin/activate
 
-./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu-host.yaml deploy -s post
+./cda.py --secret /root/pull_secret.json $CDA_OPTIONS ../hack/cluster-configs/config-dpu-host.yaml deploy -s post
 
 ret=$?
 if [ $ret == 0 ]; then


### PR DESCRIPTION
By default, our cda.py invocations don't enable debug logging. That makes debugging hard.

At least for manual usage, it will be useful if we are able to set `export CDA_OPTIONS='-v debug'` to override that setting.