### PR TITLE
[th/make-redeploy-wait] build: wait during redeploy-both before creating DpuOperatorConfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,7 @@ incremental-prep-local-deploy: tools
 local-deploy: prep-local-deploy tools manifests kustomize ## Deploy controller with images hosted on local registry
 	-$(MAKE) undeploy
 	$(KUSTOMIZE) build bin | $(KUBECTL) apply -f -
+	$(KUBECTL) -n openshift-dpu-operator wait --for=condition=ready pod --all --timeout=120s
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.


### PR DESCRIPTION
`make redeploy-both` first deploys the operator. At that point, the controller is not yet running and the validating webhook rejects the requests.
```
  KUBECONFIG=/root/kubeconfig.microshift oc create -f examples/dpu.yaml
  Error from server (InternalError): error when creating "examples/dpu.yaml": Internal error occurred: failed calling webhook "vdpuoperatorconfig.kb.io": failed to call webhook: Post "https://dpu-operator-webhook-service.openshift-dpu-operator.svc:443/validate-config-openshift-io-v1-dpuoperatorconfig?timeout=10s": no endpoints available for service "dpu-operator-webhook-service"
  make: *** [Makefile:126: redeploy-both] Error 1
```
Add a `oc wait` for the controller pod to be ready.