### PR TITLE
Change to remove +2 hack on DPU side.

### DIFF
--- a/internal/daemon/hostsidemanager.go
+++ b/internal/daemon/hostsidemanager.go
@@ -63,8 +63,7 @@ func (d *HostSideManager) CreateBridgePort(pf int, vf int, vlan int, mac string)
 				Ptype:      1,
 				MacAddress: m,
 				LogicalBridges: []string{
-					// TODO: Remove +2
-					fmt.Sprintf("%d", vf+2),
+					fmt.Sprintf("%d", vf),
 				},
 			},
 		},


### PR DESCRIPTION
This change is to close JIRA-> https://issues.redhat.com/browse/IIC-302
The corresponding change in IPU plugin(Intel's VSP), is already part of VSP's latest main(go.mod with latest VSP SHA is part of this PR-> github.com/openshift/dpu-operator/pull/356)
Note: This PR can be merged, after PR->356 passes.
