### PR TITLE
[th/tft-any-cluster] make traffic_flow_tests more configurable to use with any cluster

### DIFF
--- a/hack/traffic_flow_tests.sh
+++ b/hack/traffic_flow_tests.sh
@@ -1,22 +1,37 @@
 #!/usr/bin/env bash
 
+# The script detects the used parameters, on the assumption the cluster
+# was deployed by other scripts and via cluster-deployment-automation.
+#
+# You can however override this detection by setting the following
+# environment variables:
+# - TFT_KUBECONFIG (defaults to /root/kubeconfig.ocpcluster)
+# - TFT_KUBECONFIG_INFRA (defaults to /root/kubeconfig.microshift)
+# - TFT_WORKER (defaults to a tenent worker node named "worker-*" from `oc get nodes`)
+
 set -e
+
+TFT_KUBECONFIG="${TFT_KUBECONFIG:-/root/kubeconfig.ocpcluster}"
+TFT_KUBECONFIG_INFRA="${TFT_KUBECONFIG_INFRA:-/root/kubeconfig.microshift}"
+TFT_WORKER="${TFT_WORKER:-}"
 
 bash hack/prepare-venv.sh
 
 cd kubernetes-traffic-flow-tests
 source /tmp/tft-venv/bin/activate
 
-export KUBECONFIG=/root/kubeconfig.ocpcluster
-nodes=$(oc get nodes)
-export worker=$(echo "$nodes" | grep -oP '^worker-[^\s]*')
-if [ -z "$worker" ]; then
-  echo "Error: worker is empty"
-  exit 1
+nodes="$(oc --kubeconfig="$TFT_KUBECONFIG" get nodes)"
+worker="$TFT_WORKER"
+if [ -z "$worker" ] ; then
+    worker=$(echo "$nodes" | grep -oP '^worker-[^\s]*')
+    if [ -z "$worker" ]; then
+      echo "Error: worker is empty"
+      exit 1
+    fi
 fi
+export worker
 
-export KUBECONFIG=/root/kubeconfig.microshift
-nodes=$(oc get nodes)
+nodes="$(oc --kubeconfig="$TFT_KUBECONFIG_INFRA" get nodes)"
 export acc=$(echo "$nodes" | grep -oP '^\d+-acc')
 if [ -z "$acc" ]; then
   echo "Error: acc is empty"
@@ -27,7 +42,9 @@ temp_file=$(mktemp)
 
 envsubst < ../hack/cluster-configs/ocp-tft-config.yaml > $temp_file
 
-export TFT_MANIFESTS_OVERRIDES=../hack/cluster-configs/traffic_flow_manifests
 OUTPUT_BASE="./ft-logs/result-$(date '+%Y%m%d-%H%M%S.%4N-')"
 
+export TFT_MANIFESTS_OVERRIDES=../hack/cluster-configs/traffic_flow_manifests
+export TFT_KUBECONFIG
+export TFT_KUBECONFIG_INFRA
 ./tft.py --check -v debug --output-base "$OUTPUT_BASE" "$temp_file"

--- a/hack/traffic_flow_tests.sh
+++ b/hack/traffic_flow_tests.sh
@@ -30,6 +30,4 @@ envsubst < ../hack/cluster-configs/ocp-tft-config.yaml > $temp_file
 export TFT_MANIFESTS_OVERRIDES=../hack/cluster-configs/traffic_flow_manifests
 OUTPUT_BASE="./ft-logs/result-$(date '+%Y%m%d-%H%M%S.%4N-')"
 
-./tft.py -v debug --output-base "$OUTPUT_BASE" "$temp_file"
-
-./print_results.py "$OUTPUT_BASE"*.json
+./tft.py --check -v debug --output-base "$OUTPUT_BASE" "$temp_file"


### PR DESCRIPTION
`make e2e-test` and `make traffic-flow-tests` call
`hack/traffic_flow_tests.sh`, which runs the tests. It uses a
configuration file and detects part of the configuration.

Most notably it assumes to find the KUBECONFIG files at a certain place
and find a worker node with a certain naming pattern in `oc get node`.

This is useful for when we run the script as part of the `e2e-test,
so that the cluster is setup in a certain way that works for the traffic
flow tests script.

However, it would be useful to be able to run the tests with any
cluster, without having to follow the naming choices.

As "hack/traffic_flow_tests.sh" is quite trivial, you could just fork
the script and modify it to your needs. But optimally, we want a way to
run the test from this repository (mostly) as they are, without forking
parts.

Make that possible by honoring the environment variables

  - `$TFT_KUBECONFIG`
  - `$TFT_KUBECONFIG_INFRA`
  - `$TFT_WORKER`

with their obvious(?) meaning. Set these to overwrite what is being
tested.
