### PR TITLE
[th/prepare-venv-flock] prepare-venv: add file locking to avoid concurrent run

### DIFF
--- a/hack/prepare-venv.sh
+++ b/hack/prepare-venv.sh
@@ -27,5 +27,16 @@ setup_venv() {
     cd -
 }
 
-setup_venv cluster-deployment-automation /tmp/cda-venv "sh ./dependencies.sh"
-setup_venv kubernetes-traffic-flow-tests /tmp/tft-venv "pip install -r requirements.txt"
+setup_all_venvs() {
+    setup_venv cluster-deployment-automation /tmp/cda-venv "sh ./dependencies.sh"
+    setup_venv kubernetes-traffic-flow-tests /tmp/tft-venv "pip install -r requirements.txt"
+}
+
+exec 9> "/tmp/dpu-operator-prepare-venv.lock"
+
+while ! flock -n 9 ; do
+  echo "Waiting for lock..."
+  sleep 1
+done
+
+setup_all_venvs


### PR DESCRIPTION
We have broken "/tmp/tft-venv" environments. It's not clear how that can happen, maybe "prepare-venv.sh" runs in parallel (unlikely as it seems).

Note that setting up a python venv cannot be done concurrently.

Avoid that potential problem by adding a file lock and see whether that avoids the corruption.