### PR TITLE
[th/tft-no-debug-log] tft: don't print test output at verbose DEBUG level

### DIFF
--- a/hack/traffic_flow_tests.sh
+++ b/hack/traffic_flow_tests.sh
@@ -30,6 +30,6 @@ envsubst < ../hack/cluster-configs/ocp-tft-config.yaml > $temp_file
 export TFT_MANIFESTS_OVERRIDES=../hack/cluster-configs/traffic_flow_manifests
 OUTPUT_BASE="./ft-logs/result-$(date '+%Y%m%d-%H%M%S.%4N-')"
 
-./tft.py -v debug --output-base "$OUTPUT_BASE" "$temp_file"
+./tft.py --output-base "$OUTPUT_BASE" "$temp_file"
 
 ./print_results.py "$OUTPUT_BASE"*.json


### PR DESCRIPTION
This is more verbose and causes concerns for running out on disk space in Jenkins. Run with info debugging level only.