### PR TITLE
[th/tft-venv-update] hack: upgrade pip modules for tft-venv

### DIFF
--- a/hack/prepare-venv.sh
+++ b/hack/prepare-venv.sh
@@ -29,7 +29,7 @@ setup_venv() {
 
 setup_all_venvs() {
     setup_venv cluster-deployment-automation /tmp/cda-venv "sh ./dependencies.sh"
-    setup_venv kubernetes-traffic-flow-tests /tmp/tft-venv "pip install -r requirements.txt"
+    setup_venv kubernetes-traffic-flow-tests /tmp/tft-venv "pip install -U pip setuptools -r requirements.txt"
 }
 
 exec 9> "/tmp/dpu-operator-prepare-venv.lock"


### PR DESCRIPTION
We sometimes seem to end up with a broken venv in /tmp/tft-venv.
```
  Error processing line 1 of /tmp/tft-venv/lib64/python3.11/site-packages/distutils-precedence.pth:

    Traceback (most recent call last):
      File "<frozen site>", line 195, in addpackage
      File "<string>", line 1, in <module>
    AttributeError: module '_distutils_hack' has no attribute 'add_shim'
```
It's still not clear why this happens, but it might be related to old pip/setuptools version. Update them in the hope to resolve this issue.

---

See for example https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_dpu-operator/382/pull-ci-openshift-dpu-operator-main-make-e2e-test/1925168886706081792