### PR TITLE
[th/marvell-no-link-down] marvell: avoid setting link down to workaround kernel issue

### DIFF
--- a/internal/daemon/vendor-specific-plugins/marvell/main.go
+++ b/internal/daemon/vendor-specific-plugins/marvell/main.go
@@ -720,9 +720,15 @@ func enableIPV6LinkLocal(interfaceName string, ipv6Addr string) error {
 		// it (and don't need to toggle the link state).
 	} else {
 		// Ensure to set addrgenmode and toggle link state (which can result in creating
-		// the IPv6 link local address. Ignore errors here.
-		exec.Command("ip", "link", "set", interfaceName, "addrgenmode", "eui64").Run()
-		exec.Command("ip", "link", "set", interfaceName, "down").Run()
+		// the IPv6 link local address).
+		err2 := exec.Command("ip", "link", "set", interfaceName, "addrgenmode", "eui64").Run()
+		if err2 != nil {
+			return fmt.Errorf("Error setting link %s addrgenmode: %v", interfaceName, err2)
+		}
+		err2 = exec.Command("ip", "link", "set", interfaceName, "down").Run()
+		if err2 != nil {
+			return fmt.Errorf("Error setting link %s down after setting addrgenmode: %v", interfaceName, err2)
+		}
 	}
 
 	err := exec.Command("ip", "link", "set", interfaceName, "up").Run()


### PR DESCRIPTION
Due to [RHEL-90248](https://issues.redhat.com/browse/RHEL-90248), it seems to help to keep the SDP interfaces up at all times. The exact issue is not yet understood, but for now, avoid doing that while setting addrgenmode.

Changing the addrgenmode only takes effect (and causes kernel to regenerate IPv6 link local addresses) when bringing the link up. If it was up already, we need to bring it down first. This is what the code previously tried to do.

Let's avoid that. If the addrgenmode is already eui64, leave it.

Also, in the meantime we use a fixed link local address IPv6AddrDpu. Technically, we don't even need the EUI64 link local address.