### PR TITLE
[th/e2e-test-skip-nf] e2e_test: skip pod2pod test with NF for SKIP_NF_TESTING=1

### DIFF
--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -422,6 +422,9 @@ var _ = g.Describe("E2E integration testing", g.Ordered, func() {
 				fmt.Println("Nf pod successfully created")
 			})
 			g.It("Should support pod -> pod with Network-Function deployed", func() {
+				if skipNetworkFunctionTesting {
+					g.Skip("Skipping Network Function Testing")
+				}
 				fmt.Println("Testing pod-to-pod connectivity w/ Network Function Deployed")
 				pingTest(hostClientSet, hostRestConfig, pod1, pod2_ip, pod1.Name, pod2.Name)
 				pingTest(hostClientSet, hostRestConfig, pod2, pod1_ip, pod2.Name, pod1.Name)


### PR DESCRIPTION
Marvell does not yet pass this test. The caller (Jenkins) will set SKIP_NF_TESTING=1 when running on Marvell, to get a pass on the overall suite -- with the exeception of the tests that are known to fail and which are opted out via SKIP_NF_TESTING.