### PR TITLE
Intel VSP plugin version update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-task/task/v3 v3.43.3
 	github.com/golang/glog v1.2.4
 	github.com/gorilla/mux v1.8.1
-	github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250425184833-c99215d87699
+	github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250609180822-3e02ec6c556d
 	github.com/jaypipes/ghw v0.13.1-0.20241024164530-c1bfc6e6cd6a
 	github.com/k8snetworkplumbingwg/cni-log v0.0.0-20230801160229-b6e062c9e0f2
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -277,8 +277,8 @@ github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+h
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250425184833-c99215d87699 h1:uWW0QvVKtacTGizhcVmLlhQrBd8Aqi7gsUtOInee64k=
-github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250425184833-c99215d87699/go.mod h1:0YQiXuQYeBjxQjcxHe1NYHiuo+3kz0qeHnO0tJw2Qc0=
+github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250609180822-3e02ec6c556d h1:SfGN4hHjpHYx7dINtQ//X3nsHmaNCd9zmNDWhwRCzEc=
+github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250609180822-3e02ec6c556d/go.mod h1:0YQiXuQYeBjxQjcxHe1NYHiuo+3kz0qeHnO0tJw2Qc0=
 github.com/jaypipes/ghw v0.13.1-0.20241024164530-c1bfc6e6cd6a h1:orxBMCkYww7RFCk3iCDP9DC3l+yKtp4VdWtctCTyjPQ=
 github.com/jaypipes/ghw v0.13.1-0.20241024164530-c1bfc6e6cd6a/go.mod h1:F4UM7Ix55ONYwD3Lck2S4BI+hKezOwtizuJxXDFsioo=
 github.com/jaypipes/pcidb v1.0.1 h1:WB2zh27T3nwg8AE8ei81sNRb9yWBii3JGNJtT7K9Oic=

--- a/vendor/github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/ipuplugin/ipuplugin.go
+++ b/vendor/github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/ipuplugin/ipuplugin.go
@@ -262,6 +262,8 @@ func (s *server) Stop() {
 			log.Error(err, "unable to Delete Crs : %v", err)
 			// Do not return since we continue on error
 		}
+		//Restore Red Hat primary network path via opcodes - This is required after the primiary network P4 rules are deleted.
+		utils.RestoreRHPrimaryNetwork()
 	}
 	// Stopping the gRPC server for the DPU daemon
 	s.grpcSrvr.GracefulStop()

--- a/vendor/github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/utils/utils.go
+++ b/vendor/github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/utils/utils.go
@@ -489,3 +489,11 @@ func CopyBinary(imcPath string, vspPath string, sftpClient *sftp.Client) error {
 	}
 	return nil
 }
+
+func RestoreRHPrimaryNetwork() {
+        remoteCliCmd := "set -o pipefail && /work/scripts/post_init_app.sh"
+	_, err := RunCliCmdOnImc(remoteCliCmd, "")
+        if err != nil {
+               log.Info("RunCliCmdOnImc: Warning!. Unable to restore primary network access for to this IPU-ACC")
+        }
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -541,7 +541,7 @@ github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.1.0
 ## explicit; go 1.18
 github.com/inconshreveable/mousetrap
-# github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250425184833-c99215d87699
+# github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250609180822-3e02ec6c556d
 ## explicit; go 1.23.6
 github.com/intel/ipu-opi-plugins/ipu-plugin/ipuplugin/cmd
 github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/infrapod


### PR DESCRIPTION
This update covers restoration of primiary network path upon vsp-plugin delete triggered by dpu-operator clean-up