### PR TITLE
[th/e2e-test-sfcs] e2e_test: add test creating multiple SFCs in parallel

### DIFF
--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -435,6 +435,7 @@ var _ = g.Describe("E2E integration testing", g.Ordered, func() {
 				nfPod = testutils.EventuallyPodIsRunning(dpuSideClient, nfName, vars.Namespace, timeout_sfc_pod_running, interval)
 
 				Expect(nfPod.Spec.Containers[0].Image).To(Equal(imageRef), "Pod should have expected image")
+				Expect(testutils.PodGetDpuResourceRequests(nfPod)).To(Equal(2))
 
 				fmt.Println("Nf pod successfully created")
 			})

--- a/internal/testutils/testcluster.go
+++ b/internal/testutils/testcluster.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/dpu-operator/pkgs/vars"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -36,6 +37,18 @@ type NetworkStatus struct {
 	IPs       []string `json:"ips"`
 	Mac       string   `json:"mac"`
 	DNS       struct{} `json:"dns"`
+}
+
+func PodGetDpuResourceRequests(pod *corev1.Pod) int {
+	total := resource.MustParse("0")
+
+	for _, c := range pod.Spec.Containers {
+		if qty, ok := c.Resources.Requests["openshift.io/dpu"]; ok {
+			total.Add(qty)
+		}
+	}
+
+	return int(total.Value())
 }
 
 func GetPod(c client.Client, name string, namespace string) *corev1.Pod {


### PR DESCRIPTION
Create a bunch of SFCs. As the "openshift.io/dpu" resource is limited, they probably cannot start all right away. However, we are also deleting the SFCs after a short while, so eventually all SFCs should have their pods running and quit.

https://issues.redhat.com/browse/IIC-685