### PR TITLE
Improve log message on why test failed

### DIFF
--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -431,13 +431,10 @@ var _ = g.Describe("E2E integration testing", g.Ordered, func() {
 				err = dpuSideClient.List(context.TODO(), podList, client.InNamespace(vars.Namespace))
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(func() bool {
-					nfPod = testutils.GetPod(dpuSideClient, nfName, vars.Namespace)
-					if nfPod != nil {
-						return nfPod.Spec.Containers[0].Image == imageRef && nfPod.Status.Phase == corev1.PodRunning
-					}
-					return false
-				}, timeout, interval).Should(BeTrue())
+				nfPod = testutils.EventuallyPodIsRunning(dpuSideClient, nfName, vars.Namespace, timeout, interval)
+
+				Expect(nfPod.Spec.Containers[0].Image).To(Equal(imageRef), "Pod should have expected image")
+
 				fmt.Println("Nf pod successfully created")
 			})
 			g.It("Should support pod -> pod with Network-Function deployed", func() {


### PR DESCRIPTION
We're hitting a flake where the pod is not coming up on time during SFC creation. This PR improves the logging around the whole creation process by splitting it up in 2 Eventually blocks. First, the pod needs to be created. Next, it should eventually be in running state. If it's not, we need to know what state it is in do help debug this.