### PR TITLE
Dectection loop and handle racy starts

### DIFF
--- a/cmd/daemon/daemon.go
+++ b/cmd/daemon/daemon.go
@@ -33,7 +33,7 @@ func main() {
 
 	platform := &platform.HardwarePlatform{}
 	d := daemon.NewDaemon(afero.NewOsFs(), platform, mode, ctrl.GetConfigOrDie(), vspImages, utils.NewPathManager("/"))
-	if err := d.ListenAndServe(context.Background()); err != nil {
+	if err := d.PrepareAndServe(context.Background()); err != nil {
 		log.Error(err, "Failed to run daemon")
 		panic(err)
 	}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -64,7 +64,7 @@ var _ = g.Describe("Full Daemon", func() {
 		d = daemon.NewDaemon(fs, fakePlatform, "dpu", config, createVspTestImages(), pathManager)
 		go func() {
 			defer close(daemonDone)
-			d.ListenAndServe(ctx)
+			d.PrepareAndServe(ctx)
 			// Always wait for context cancellation to ensure proper test synchronization
 			// If ListenAndServe blocked until context cancellation, this returns immediately
 			// If ListenAndServe failed early, we wait for context cancellation


### PR DESCRIPTION
- Run the side manager in a go routine. Final preparation PR for DPU CR.
- Avoid a spurious restart of dpu daemon as it tries to connect to vsp that's not up yet by retrying for 10 seconds.