### PR TITLE
taskfiles: drop workaround for deploying marvell

### DIFF
--- a/taskfiles/clusters.yaml
+++ b/taskfiles/clusters.yaml
@@ -22,13 +22,10 @@ tasks:
     internal: true
     deps:
       - task: prepare-e2e-test
-    vars:
-      CDA_MARVELL_TOOLS_EXTRA_ARGS: "--octep-cp-agent-service-disable"
     cmds:
       - >
         cd cluster-deployment-automation;
         source /tmp/cda-venv/bin/activate;
-        export CDA_MARVELL_TOOLS_EXTRA_ARGS="{{.CDA_MARVELL_TOOLS_EXTRA_ARGS}}";
         ./cda.py --secret /root/pull_secret.json ../hack/cluster-configs/config-dpu.yaml deploy
 
   deploy-clusters-host-phase-1:


### PR DESCRIPTION
With [1], we no longer need to set the environment variable. Drop this.

[1] https://github.com/bn222/cluster-deployment-automation/pull/355