### PR TITLE
Add Intel NetSec Accelerator Support with DPU Operator

### DIFF
--- a/Dockerfile.IntelNetSecVSP.rhel
+++ b/Dockerfile.IntelNetSecVSP.rhel
@@ -1,0 +1,36 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+COPY . .
+# Build
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+
+# Due to https://github.com/golang/go/issues/70329 cross-compilation hangs at times.
+# As a temporary workaround, we can try specifying GOMAXPROCS=2 to relieve this issue
+RUN mkdir -p /bin && \
+    GOMAXPROCS=2 CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} make build-intel-netsec-vsp
+
+# Use distroless as minimal base image to package the Marvell VSP binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
+ARG TARGETARCH
+COPY --from=builder /workspace/bin/vsp-intel-netsec.${TARGETARCH} /vsp-intel-netsec
+
+RUN yum update -y \
+    && yum install -y \
+       net-tools \
+       kmod \
+       pciutils \
+       iputils \
+       iproute \
+    && yum clean all \
+    && rm -rf /var/cache/dnf
+
+USER 0
+
+ENTRYPOINT ["/vsp-intel-netsec"]

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ fast-test:
 
 
 .PHONY: build
-build: manifests generate fmt vet build-manager build-daemon build-intel-vsp build-marvell-vsp build-network-resources-injector
+build: manifests generate fmt vet build-manager build-daemon build-intel-vsp build-marvell-vsp build-intel-netsec-vsp build-network-resources-injector
 	@echo "Built all components"
 
 .PHONY: build-manager
@@ -170,6 +170,10 @@ build-intel-vsp:
 .PHONY: build-marvell-vsp
 build-marvell-vsp:
 	go run tools/task/task.go build-bin-marvell-vsp
+
+.PHONY: build-intel-netsec-vsp
+build-intel-netsec-vsp:
+	go run tools/task/task.go build-bin-intel-netsec-vsp
 
 .PHONY: build-network-resources-injector
 build-network-resources-injector:

--- a/config/dev/local-images-template.yaml
+++ b/config/dev/local-images-template.yaml
@@ -26,6 +26,8 @@ spec:
           value: {{ .RegistryURL }}/intel-vsp-p4:dev
         - name: MarvellVspImage
           value: {{ .RegistryURL }}/mrvl-vsp:dev
+        - name: IntelNetSecVspImage
+          value: {{ .RegistryURL }}/intel-netsec-vsp:dev
         - name: IMAGE_PULL_POLICIES
           value: Always
         - name: NETWORK_RESOURCES_INJECTOR_IMAGE

--- a/internal/controller/bindata/daemon/99.daemonset.yaml
+++ b/internal/controller/bindata/daemon/99.daemonset.yaml
@@ -46,6 +46,8 @@ spec:
           value: {{.IntelVspP4Image}}
         - name: MarvellVspImage
           value: {{.MarvellVspImage}}
+        - name: IntelNetSecVspImage
+          value: {{.IntelNetSecVspImage}}
         volumeMounts:
         - name: devicesock
           mountPath: /var/lib/kubelet/

--- a/internal/daemon/device-handler/dpu-device-handler/dpudevicehandler.go
+++ b/internal/daemon/device-handler/dpu-device-handler/dpudevicehandler.go
@@ -101,14 +101,19 @@ func (d *dpuDeviceHandler) SetupDevices() error {
 
 	numVfs, err := d.vsp.SetNumVfs(8)
 	if err != nil {
-		return fmt.Errorf("Failed to set sriov numVfs: %v", err)
+		// Currently NF devices do not require any setup outside the VSP
+		// ignore the error if we are in DPU mode.
+		if d.dpuMode {
+			d.log.Info("Failed to set sriov numVFs, but ignoring error in DPU mode", "error", err)
+		} else {
+			return fmt.Errorf("failed to set sriov numVfs: %v", err)
+		}
+	} else {
+		if numVfs.VfCnt == 0 {
+			return fmt.Errorf("SetNumVfs ran, but numVfs == %d", numVfs.VfCnt)
+		}
+		d.log.Info("Num VFs set by VSP", "vf_count", numVfs.VfCnt)
 	}
-
-	if numVfs.VfCnt == 0 {
-		return fmt.Errorf("SetNumVfs ran, but numVfs == 0")
-	}
-
-	d.log.Info("Num VFs set by VSP", "vf_count", numVfs.VfCnt)
 
 	return nil
 }

--- a/internal/daemon/dpusidemanager_test.go
+++ b/internal/daemon/dpusidemanager_test.go
@@ -76,7 +76,7 @@ var _ = g.Describe("DPU side manager", Ordered, func() {
 			mockVspDone <- err
 		}()
 
-		dpuPlugin, err := plugin.NewGrpcPlugin(true,
+		dpuPlugin, err := plugin.NewGrpcPlugin(true, "testDpuIdentifier",
 			client,
 			plugin.WithPathManager(pathManager))
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/daemon/vendor-specific-plugins/common/vspnetutils.go
+++ b/internal/daemon/vendor-specific-plugins/common/vspnetutils.go
@@ -1,0 +1,112 @@
+package vspnetutils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/openshift/dpu-operator/internal/platform"
+	"github.com/spf13/afero"
+	"k8s.io/klog/v2"
+)
+
+// SetSriovNumVfs sets the number of virtual functions (VFs) for a given PCI address.
+func SetSriovNumVfs(fs afero.Fs, pciAddr string, numVfs int) error {
+	klog.Infof("SetSriovNumVfs(): set NumVfs device %s numvfs %d", pciAddr, numVfs)
+	numVfsFilePath := filepath.Join("/sys/bus/pci/devices", pciAddr, "sriov_numvfs")
+	bs := []byte(strconv.Itoa(numVfs))
+	err := afero.WriteFile(fs, numVfsFilePath, []byte("0"), os.ModeAppend)
+	if err != nil {
+		klog.Errorf("SetSriovNumVfs(): fail to reset NumVfs file path %s, err %v", numVfsFilePath, err)
+		return err
+	}
+	if numVfs == 0 {
+		return nil
+	}
+	err = afero.WriteFile(fs, numVfsFilePath, bs, os.ModeAppend)
+	if err != nil {
+		klog.Errorf("SetSriovNumVfs(): fail to set NumVfs file path %s, err %v", numVfsFilePath, err)
+		return err
+	}
+	return nil
+}
+
+// TODO: Tech Debt, commands that use exec could be abstrated to a testable interface.
+// linkHasAddrgenmodeEui64 checks if the given net interface has addrgenmode set to eui64.
+func linkHasAddrgenmodeEui64(interfaceName string) bool {
+	out, err := exec.Command("ip", "-d", "link", "show", "dev", interfaceName).Output()
+	return err == nil && strings.Contains(string(out), "addrgenmode eui64")
+}
+
+// enableOptomisticDuplicateAddressDetection enables optimistic duplicate address detection on the given net interface.
+func enableOptomisticDuplicateAddressDetection(fs afero.Fs, interfaceName string) error {
+	optimistic_dad_file := "/proc/sys/net/ipv6/conf/" + interfaceName + "/optimistic_dad"
+	err := afero.WriteFile(fs, optimistic_dad_file, []byte("1"), os.ModeAppend)
+	return err
+}
+
+// TODO: Tech Debt, commands that use exec could be abstrated to a testable interface.
+// EnableIPV6LinkLocal enables IPv6 link local address on the given net interface with the provided interface nad ipv6 address.
+func EnableIPV6LinkLocal(fs afero.Fs, interfaceName string, ipv6Addr string) error {
+	// Tell NetworkManager to not manage our interface.
+	err1 := exec.Command("nsenter", "-t", "1", "-m", "-u", "-n", "-i", "--", "nmcli", "device", "set", interfaceName, "managed", "no").Run()
+	if err1 != nil {
+		// This error may be fine. Maybe our host doesn't even run
+		// NetworkManager. Ignore.
+		klog.Infof("EnableIPV6LinkLocal() nmcli device set %s managed no failed with error %v", interfaceName, err1)
+	}
+
+	err1 = enableOptomisticDuplicateAddressDetection(fs, interfaceName)
+	if err1 != nil {
+		klog.Errorf("EnableIPV6LinkLocal() Error setting optimistic dad: %v", err1)
+	}
+
+	if linkHasAddrgenmodeEui64(interfaceName) {
+		// Kernel may require that the SDP interfaces are up at all times (RHEL-90248).
+		// If the addrgenmode is already eui64, assume we are fine and don't need to reset
+		// it (and don't need to toggle the link state).
+	} else {
+		// Ensure to set addrgenmode and toggle link state (which can result in creating
+		// the IPv6 link local address).
+		err2 := exec.Command("ip", "link", "set", interfaceName, "addrgenmode", "eui64").Run()
+		if err2 != nil {
+			return fmt.Errorf("error setting link %s addrgenmode: %v", interfaceName, err2)
+		}
+		err2 = exec.Command("ip", "link", "set", interfaceName, "down").Run()
+		if err2 != nil {
+			return fmt.Errorf("error setting link %s down after setting addrgenmode: %v", interfaceName, err2)
+		}
+	}
+
+	err := exec.Command("ip", "link", "set", interfaceName, "up").Run()
+	if err != nil {
+		return fmt.Errorf("error setting link %s up: %v", interfaceName, err)
+	}
+
+	err = exec.Command("ip", "addr", "replace", ipv6Addr+"/64", "dev", interfaceName, "optimistic").Run()
+	if err != nil {
+		return fmt.Errorf("error configuring IPv6 address %s/64 on link %s: %v", ipv6Addr, interfaceName, err)
+	}
+	return nil
+}
+
+// GetNetDevNameFromPCIeAddr retrieves the network device name associated with a given PCIe address.
+// This can fail if the given PCIe address is not a NetDev or the driver is not loaded correctly.
+func GetNetDevNameFromPCIeAddr(platform platform.Platform, pcieAddress string) (string, error) {
+	nics, err := platform.NetDevs()
+	if err != nil {
+		return "", fmt.Errorf("failed to get network devices: %w", err)
+	}
+
+	for _, nic := range nics {
+		if nic.PCIAddress != nil && *nic.PCIAddress == pcieAddress {
+			klog.Infof("GetNetDevNameFromPCIeAddr(): found DPU network device %s %s", nic.Name, *nic.PCIAddress)
+			return nic.Name, nil
+		}
+	}
+
+	return "", fmt.Errorf("network device not found for PCI address %s", pcieAddress)
+}

--- a/internal/daemon/vendor-specific-plugins/intel-netsec/main.go
+++ b/internal/daemon/vendor-specific-plugins/intel-netsec/main.go
@@ -1,0 +1,341 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"github.com/jaypipes/ghw"
+	pb "github.com/openshift/dpu-operator/dpu-api/gen"
+	"github.com/openshift/dpu-operator/internal/daemon/plugin"
+	vspnetutils "github.com/openshift/dpu-operator/internal/daemon/vendor-specific-plugins/common"
+	"github.com/openshift/dpu-operator/internal/platform"
+	"github.com/openshift/dpu-operator/internal/utils"
+	opi "github.com/opiproject/opi-api/network/evpn-gw/v1alpha1/gen/go"
+	"github.com/spf13/afero"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+const (
+	Version                              string = "0.0.1"
+	IPv6AddrDpu                          string = "fe80::1"
+	IPv6AddrHost                         string = "fe80::2"
+	DefaultPort                          int32  = 8085
+	IntelVendorID                        string = "8086"
+	IntelNetSecHostVfDeviceID            string = "1889" // Intel Corporation Ethernet Adaptive Virtual Function
+	IntelNetSecDpuSFPf0PCIeAddress       string = "0000:f4:00.0"
+	IntelNetSecDpuSFPf1PCIeAddress       string = "0000:f4:00.1"
+	IntelNetSecDpuBackplanef2PCIeAddress string = "0000:f4:00.2"
+	IntelNetSecDpuBackplanef3PCIeAddress string = "0000:f4:00.3"
+)
+
+type intelNetSecVspServer struct {
+	pb.UnimplementedLifeCycleServiceServer
+	pb.UnimplementedNetworkFunctionServiceServer
+	pb.UnimplementedDeviceServiceServer
+	opi.UnimplementedBridgePortServiceServer
+	log            logr.Logger
+	grpcServer     *grpc.Server
+	wg             sync.WaitGroup
+	done           chan error
+	fs             afero.Fs
+	startedWg      sync.WaitGroup
+	pathManager    utils.PathManager
+	version        string
+	isDPUMode      bool
+	platform       platform.Platform
+	dpuIdentifier  plugin.DpuIdentifier
+	dpuPcieAddress string
+}
+
+// getVFs retrieves the VF PCIe addresses for the given PF PCIe address for Intel NetSec accelerator devices.
+func (vsp *intelNetSecVspServer) getVFs(pfPCIeAddress string) ([]string, error) {
+	var pciVFAddresses []string
+
+	devices, err := vsp.platform.PciDevices()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get PCI devices: %v", err)
+	}
+
+	bus := ghw.PCIAddressFromString(pfPCIeAddress).Bus
+	for _, pci := range devices {
+		if ghw.PCIAddressFromString(pci.Address).Bus == bus {
+			if pci.Vendor.ID == IntelVendorID &&
+				pci.Product.ID == IntelNetSecHostVfDeviceID {
+				pciVFAddresses = append(pciVFAddresses, pci.Address)
+			}
+		}
+	}
+
+	numVfs := len(pciVFAddresses)
+	vsp.log.Info("getVFs(): found VFs", "NumVFs", numVfs, "DpuPcieAddress", vsp.dpuPcieAddress)
+	return pciVFAddresses, nil
+}
+
+func (vsp *intelNetSecVspServer) configureIP(dpuMode bool) (pb.IpPort, error) {
+	var ifName string
+	var addr string
+	var err error
+	if dpuMode {
+		// All NetSec DPU devices have the same internal PCIe Addresses. Netdev names can change with each RHEL release.
+		ifName, err = vspnetutils.GetNetDevNameFromPCIeAddr(vsp.platform, IntelNetSecDpuBackplanef2PCIeAddress)
+		if err != nil {
+			klog.Errorf("Error getting netdev name from PCIe address in DPU mode %s: %v", IntelNetSecDpuBackplanef2PCIeAddress, err)
+			return pb.IpPort{}, err
+		}
+		addr = IPv6AddrDpu
+	} else {
+		ifName, err = vspnetutils.GetNetDevNameFromPCIeAddr(vsp.platform, vsp.dpuPcieAddress)
+		if err != nil {
+			klog.Errorf("Error getting netdev name from PCIe address in Host mode %s: %v", vsp.dpuPcieAddress, err)
+			return pb.IpPort{}, err
+		}
+		addr = IPv6AddrHost
+	}
+
+	vsp.log.Info("configureIP(): DpuMode", "DpuMode", dpuMode, "IfName", ifName, "Addr", addr)
+
+	err = vspnetutils.EnableIPV6LinkLocal(vsp.fs, ifName, addr)
+	addr = IPv6AddrDpu
+	if err != nil {
+		klog.Errorf("Error occurred in enabling IPv6 Link local Address: %v", err)
+		return pb.IpPort{}, err
+	}
+	var connStr string
+	if dpuMode {
+		connStr = "[" + addr + "%" + ifName + "]"
+	} else {
+		connStr = "[" + addr + "%25" + ifName + "]"
+	}
+
+	klog.Infof("IPv6 Link Local Address Enabled IfName: %v, Connection String: %s", ifName, connStr)
+
+	return pb.IpPort{
+		Ip:   connStr,
+		Port: DefaultPort,
+	}, nil
+}
+
+// GetDpuPcieAddress retrieves the PCIe address of the DPU based on the provided DPU identifier.
+// We only return the PCIe address of the first function (function 0) of the DPU device.
+func (vsp *intelNetSecVspServer) GetDpuPcieAddress(dpuIdentifier plugin.DpuIdentifier) (string, error) {
+	if vsp.isDPUMode {
+		return "", nil
+	}
+
+	devices, err := vsp.platform.PciDevices()
+	if err != nil {
+		return "", fmt.Errorf("Error getting devices: %v", err)
+	}
+
+	for _, pci := range devices {
+		if pci.Vendor.ID == platform.IntelVendorID && pci.Product.ID == platform.IntelNetSecHostDeviceID {
+			serial, err := vsp.platform.ReadDeviceSerialNumber(pci)
+			if err != nil {
+				// Intel NetSec Network Devices should return a serial number.
+				return "", fmt.Errorf("error reading device serial number for %s: %v", pci.Address, err)
+			}
+			if plugin.DpuIdentifier(serial) == dpuIdentifier {
+				// Intel NetSec Accelerator's first device should have function 0.
+				if ghw.PCIAddressFromString(pci.Address).Function == "0" {
+					return pci.Address, nil
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("DPU PCIe address not found for identifier: %s", dpuIdentifier)
+}
+
+func (vsp *intelNetSecVspServer) Init(ctx context.Context, in *pb.InitRequest) (*pb.IpPort, error) {
+	var err error
+	klog.Infof("Received Init() request: DpuMode: %v DpuIdentifier: %v", in.DpuMode, in.DpuIdentifier)
+	vsp.isDPUMode = in.DpuMode
+	vsp.dpuIdentifier = plugin.DpuIdentifier(in.DpuIdentifier)
+
+	vsp.dpuPcieAddress, err = vsp.GetDpuPcieAddress(vsp.dpuIdentifier)
+	if err != nil {
+		klog.Errorf("Error getting DPU PCIe address: %v", err)
+		return nil, err
+	}
+
+	ipPort, err := vsp.configureIP(in.DpuMode)
+
+	return &pb.IpPort{
+		Ip:   ipPort.Ip,
+		Port: ipPort.Port,
+	}, err
+}
+
+// TODO: Implement this correctly, it needs to handle VETH interfaces for service function chaining.
+func (vsp *intelNetSecVspServer) GetDevices(ctx context.Context, in *pb.Empty) (*pb.DeviceListResponse, error) {
+	klog.Info("Received GetDevices() request")
+	devices := make(map[string]*pb.Device)
+
+	var pfPcieAddress string
+	if vsp.isDPUMode {
+		pfPcieAddress = IntelNetSecDpuBackplanef2PCIeAddress
+	} else {
+		pfPcieAddress = vsp.dpuPcieAddress
+	}
+
+	vfs, err := vsp.getVFs(pfPcieAddress)
+	if err != nil {
+		klog.Errorf("Error getting VFs: %v", err)
+		return nil, err
+	}
+
+	for _, vf := range vfs {
+		klog.Infof("Adding device %s to the response", vf)
+		devices[vf] = &pb.Device{
+			ID:     vf,
+			Health: "Healthy",
+		}
+	}
+
+	return &pb.DeviceListResponse{
+		Devices: devices,
+	}, nil
+}
+
+// TODO: Implement this
+func (vsp *intelNetSecVspServer) CreateBridgePort(ctx context.Context, in *opi.CreateBridgePortRequest) (*opi.BridgePort, error) {
+	vsp.log.Info("Received CreateBridgePort() request", "BridgePortId", in.BridgePortId, "BridgePortId", in.BridgePortId)
+	return &opi.BridgePort{}, nil
+}
+
+// TODO: Implement this
+func (vsp *intelNetSecVspServer) DeleteBridgePort(ctx context.Context, in *opi.DeleteBridgePortRequest) (*emptypb.Empty, error) {
+	vsp.log.Info("Received DeleteBridgePort() request", "Name", in.Name, "AllowMissing", in.AllowMissing)
+	return nil, nil
+}
+
+// TODO: Implement this
+func (vsp *intelNetSecVspServer) CreateNetworkFunction(ctx context.Context, in *pb.NFRequest) (*pb.Empty, error) {
+	vsp.log.Info("Received CreateNetworkFunction() request", "Input", in.Input, "Output", in.Output)
+	return nil, nil
+}
+
+// TODO: Implement this
+func (vsp *intelNetSecVspServer) DeleteNetworkFunction(ctx context.Context, in *pb.NFRequest) (*pb.Empty, error) {
+	vsp.log.Info("Received DeleteNetworkFunction() request", "Input", in.Input, "Output", in.Output)
+	return nil, nil
+}
+
+// TODO: FIX ME: This function is not implemented fully for Service Function Chaining.
+// SetNumVfs function to set the number of VFs with the given context and VfCount
+func (vsp *intelNetSecVspServer) SetNumVfs(ctx context.Context, in *pb.VfCount) (*pb.VfCount, error) {
+	klog.Infof("Received SetNumVfs() request: VfCnt: %v", in.VfCnt)
+	var err error
+
+	if vsp.isDPUMode {
+		err = vspnetutils.SetSriovNumVfs(vsp.fs, IntelNetSecDpuBackplanef2PCIeAddress, int(in.VfCnt))
+	} else {
+		err = vspnetutils.SetSriovNumVfs(vsp.fs, vsp.dpuPcieAddress, int(in.VfCnt))
+	}
+
+	return in, err
+}
+
+func (vsp *intelNetSecVspServer) Listen() (net.Listener, error) {
+	err := vsp.pathManager.EnsureSocketDirExists(vsp.pathManager.VendorPluginSocket())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create run directory for vendor plugin socket: %v", err)
+	}
+	listener, err := net.Listen("unix", vsp.pathManager.VendorPluginSocket())
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on the vendor plugin socket: %v", err)
+	}
+	vsp.grpcServer = grpc.NewServer()
+	pb.RegisterNetworkFunctionServiceServer(vsp.grpcServer, vsp)
+	pb.RegisterLifeCycleServiceServer(vsp.grpcServer, vsp)
+	pb.RegisterDeviceServiceServer(vsp.grpcServer, vsp)
+	opi.RegisterBridgePortServiceServer(vsp.grpcServer, vsp)
+	klog.Infof("gRPC server is listening on %v", listener.Addr())
+
+	return listener, nil
+}
+
+func (vsp *intelNetSecVspServer) Serve(listener net.Listener) error {
+	vsp.wg.Add(1)
+	go func() {
+		vsp.version = Version
+		klog.Infof("Starting Intel NetSec VSP Server: Version: %s", vsp.version)
+		if err := vsp.grpcServer.Serve(listener); err != nil {
+			vsp.done <- err
+		} else {
+			vsp.done <- nil
+		}
+		klog.Info("Stopping Intel NetSec VSP Server")
+		vsp.wg.Done()
+	}()
+
+	// Block on any go routines writing to the done channel when an error occurs or they
+	// are forced to exit.
+	err := <-vsp.done
+
+	vsp.grpcServer.Stop()
+	vsp.wg.Wait()
+	vsp.startedWg.Done()
+	return err
+}
+
+func (vsp *intelNetSecVspServer) Stop() {
+	vsp.grpcServer.Stop()
+	vsp.done <- nil
+	vsp.startedWg.Wait()
+}
+
+func WithPathManager(pathManager utils.PathManager) func(*intelNetSecVspServer) {
+	return func(vsp *intelNetSecVspServer) {
+		vsp.pathManager = pathManager
+	}
+}
+
+func NewIntelNetSecVspServer(opts ...func(*intelNetSecVspServer)) *intelNetSecVspServer {
+	var mode string
+	flag.StringVar(&mode, "mode", "", "Mode for the daemon, can be either host or dpu")
+	options := zap.Options{
+		Development: true,
+		Level:       zapcore.DebugLevel,
+	}
+	options.BindFlags(flag.CommandLine)
+	flag.Parse()
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&options)))
+	vsp := &intelNetSecVspServer{
+		log:         ctrl.Log.WithName("IntelNetSecVsp"),
+		pathManager: *utils.NewPathManager("/"),
+		done:        make(chan error),
+		fs:          afero.NewOsFs(),
+		platform:    &platform.HardwarePlatform{},
+	}
+
+	for _, opt := range opts {
+		opt(vsp)
+	}
+
+	return vsp
+}
+
+func main() {
+	intelNetSecVspServer := NewIntelNetSecVspServer()
+	listener, err := intelNetSecVspServer.Listen()
+
+	if err != nil {
+		intelNetSecVspServer.log.Error(err, "Failed to Listen Intel NetSec VSP server")
+		return
+	}
+	err = intelNetSecVspServer.Serve(listener)
+	if err != nil {
+		intelNetSecVspServer.log.Error(err, "Failed to serve  Intel NetSec VSP server")
+		return
+	}
+}

--- a/internal/platform/ipu.go
+++ b/internal/platform/ipu.go
@@ -42,7 +42,7 @@ func (d *IntelDetector) isVirtualFunction(device string) (bool, error) {
 	}
 }
 
-func (d *IntelDetector) IsDPU(pci ghw.PCIDevice) (bool, error) {
+func (d *IntelDetector) IsDPU(platform Platform, pci ghw.PCIDevice, dpuDevices []plugin.DpuIdentifier) (bool, error) {
 	// VFs for the Intel IPU have the same PCIe info as the PF
 	isVF, err := d.isVirtualFunction(pci.Address)
 	if err != nil {
@@ -67,7 +67,12 @@ func (pi *IntelDetector) IsDpuPlatform(platform Platform) (bool, error) {
 	return false, nil
 }
 
-func (pi *IntelDetector) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client, pm utils.PathManager) (*plugin.GrpcPlugin, error) {
+func (pi *IntelDetector) GetDpuIdentifier(platform Platform, pci *ghw.PCIDevice) (plugin.DpuIdentifier, error) {
+	// TODO: Implement a way to get the DPU identifier.
+	return "", nil
+}
+
+func (pi *IntelDetector) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client, pm utils.PathManager, dpuIdentifier plugin.DpuIdentifier) (*plugin.GrpcPlugin, error) {
 	p4Image := os.Getenv(VspP4ImageIntelEnv)
 	if p4Image == "" {
 		return nil, errors.Errorf("Error getting vsp-p4 image: Can't start Intel vsp without vsp-p4")
@@ -78,7 +83,7 @@ func (pi *IntelDetector) VspPlugin(dpuMode bool, vspImages map[string]string, cl
 	template_vars.VendorSpecificPluginImage = vspImages[plugin.VspImageIntel]
 	template_vars.Command = `[ "/ipuplugin" ]`
 	template_vars.Args = args
-	return plugin.NewGrpcPlugin(dpuMode, client, plugin.WithVsp(template_vars), plugin.WithPathManager(pm))
+	return plugin.NewGrpcPlugin(dpuMode, dpuIdentifier, client, plugin.WithVsp(template_vars), plugin.WithPathManager(pm))
 }
 
 func (d *IntelDetector) GetVendorName() string {

--- a/internal/platform/marvell-dpu.go
+++ b/internal/platform/marvell-dpu.go
@@ -28,9 +28,7 @@ func (d *MarvellDetector) Name() string {
 	return d.name
 }
 
-// IsDPU checks if the PCI device Attached to the host is a Marvell DPU
-// It returns true if device has Marvell DPU
-func (pi *MarvellDetector) IsDPU(pci ghw.PCIDevice) (bool, error) {
+func (pi *MarvellDetector) IsDPU(platform Platform, pci ghw.PCIDevice, dpuDevices []plugin.DpuIdentifier) (bool, error) {
 	if pci.Vendor.ID == MrvlVendorID &&
 		pci.Product.ID == MrvlHostDeviceID {
 		return true, nil
@@ -56,11 +54,16 @@ func (pi *MarvellDetector) IsDpuPlatform(platform Platform) (bool, error) {
 	return false, nil
 }
 
-func (pi *MarvellDetector) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client, pm utils.PathManager) (*plugin.GrpcPlugin, error) {
+func (pi *MarvellDetector) GetDpuIdentifier(platform Platform, pci *ghw.PCIDevice) (plugin.DpuIdentifier, error) {
+	// TODO: Implement a way to get the DPU identifier.
+	return "", nil
+}
+
+func (pi *MarvellDetector) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client, pm utils.PathManager, dpuIdentifier plugin.DpuIdentifier) (*plugin.GrpcPlugin, error) {
 	template_vars := plugin.NewVspTemplateVars()
 	template_vars.VendorSpecificPluginImage = vspImages[plugin.VspImageMarvell]
 	template_vars.Command = `[ "/vsp-mrvl" ]`
-	return plugin.NewGrpcPlugin(dpuMode, client, plugin.WithVsp(template_vars), plugin.WithPathManager(pm))
+	return plugin.NewGrpcPlugin(dpuMode, dpuIdentifier, client, plugin.WithVsp(template_vars), plugin.WithPathManager(pm))
 }
 
 // GetVendorName returns the name of the vendor

--- a/internal/platform/netsec-accelerator.go
+++ b/internal/platform/netsec-accelerator.go
@@ -1,0 +1,86 @@
+package platform
+
+import (
+	"github.com/jaypipes/ghw"
+	"github.com/openshift/dpu-operator/internal/daemon/plugin"
+	"github.com/openshift/dpu-operator/internal/utils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/kind/pkg/errors"
+)
+
+const (
+	IntelVendorID                        string = "8086"
+	IntelNetSecBackplaneDeviceID         string = "124c"
+	IntelNetSecSFPDeviceID               string = "124d"
+	IntelNetSecHostDeviceID              string = "1599"
+	IntelNetSecHostVfDeviceID            string = "1889" // Intel Corporation Ethernet Adaptive Virtual Function
+	IntelNetSecDpuSFPf0PCIeAddress       string = "0000:f4:00.0"
+	IntelNetSecDpuSFPf1PCIeAddress       string = "0000:f4:00.1"
+	IntelNetSecDpuBackplanef2PCIeAddress string = "0000:f4:00.2"
+	IntelNetSecDpuBackplanef3PCIeAddress string = "0000:f4:00.3"
+)
+
+type NetsecAcceleratorDetector struct {
+	name string
+}
+
+func NewNetsecAcceleratorDetector() *NetsecAcceleratorDetector {
+	return &NetsecAcceleratorDetector{name: "Intel Netsec Accelerator"}
+}
+
+func (d *NetsecAcceleratorDetector) Name() string {
+	return d.name
+}
+
+func (pi *NetsecAcceleratorDetector) IsDPU(platform Platform, pci ghw.PCIDevice, dpuDevices []plugin.DpuIdentifier) (bool, error) {
+	if pci.Vendor.ID == IntelVendorID &&
+		pci.Product.ID == IntelNetSecHostDeviceID {
+		serial, err := platform.ReadDeviceSerialNumber(&pci)
+		if err != nil {
+			// Intel NetSec Network Devices should return a serial number.
+			return false, errors.Errorf("Error reading device serial number for %s: %v", pci.Address, err)
+		}
+		for _, dpuDevice := range dpuDevices {
+			if plugin.DpuIdentifier(serial) == dpuDevice {
+				// This is a dual port device ignore the second port.
+				return false, nil
+			}
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (pi *NetsecAcceleratorDetector) IsDpuPlatform(platform Platform) (bool, error) {
+	devices, err := platform.PciDevices()
+	if err != nil {
+		return false, errors.Errorf("Error getting devices: %v", err)
+	}
+
+	for _, pci := range devices {
+		if pci.Vendor.ID == IntelVendorID &&
+			pci.Product.ID == IntelNetSecBackplaneDeviceID {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (pi *NetsecAcceleratorDetector) GetDpuIdentifier(platform Platform, pci *ghw.PCIDevice) (plugin.DpuIdentifier, error) {
+	serial, err := platform.ReadDeviceSerialNumber(pci)
+	return plugin.DpuIdentifier(serial), err
+}
+
+func (pi *NetsecAcceleratorDetector) VspPlugin(dpuMode bool, vspImages map[string]string, client client.Client, pm utils.PathManager, dpuIdentifier plugin.DpuIdentifier) (*plugin.GrpcPlugin, error) {
+	template_vars := plugin.NewVspTemplateVars()
+	template_vars.VendorSpecificPluginImage = vspImages[plugin.VspImageIntelNetSec]
+	template_vars.Command = `[ "/vsp-intel-netsec" ]`
+	return plugin.NewGrpcPlugin(dpuMode, dpuIdentifier, client, plugin.WithVsp(template_vars), plugin.WithPathManager(pm))
+}
+
+// GetVendorName returns the name of the vendor
+func (d *NetsecAcceleratorDetector) GetVendorName() string {
+	return "intel"
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -1,13 +1,20 @@
 package platform
 
 import (
-	"github.com/jaypipes/ghw"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
+
+	"github.com/jaypipes/ghw"
 )
 
 type Platform interface {
 	PciDevices() ([]*ghw.PCIDevice, error)
+	NetDevs() ([]*ghw.NIC, error)
 	Product() (*ghw.ProductInfo, error)
+	ReadDeviceSerialNumber(pciDevice *ghw.PCIDevice) (string, error)
 }
 
 type HardwarePlatform struct{}
@@ -24,13 +31,55 @@ func (hp *HardwarePlatform) PciDevices() ([]*ghw.PCIDevice, error) {
 	return pciInfo.Devices, nil
 }
 
+func (hp *HardwarePlatform) NetDevs() ([]*ghw.NIC, error) {
+	netInfo, err := ghw.Network()
+	if err != nil {
+		return nil, err
+	}
+	return netInfo.NICs, nil
+}
+
 func (hp *HardwarePlatform) Product() (*ghw.ProductInfo, error) {
 	return ghw.Product()
+}
+
+func (hp *HardwarePlatform) ReadDeviceSerialNumber(pciDevice *ghw.PCIDevice) (string, error) {
+	if pciDevice == nil {
+		return "", fmt.Errorf("nil PCI device provided")
+	}
+
+	devicePath := filepath.Join("/sys/bus/pci/devices", pciDevice.Address, "config")
+
+	file, err := os.Open(devicePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open config space: %v", err)
+	}
+	defer file.Close()
+
+	// Seek to offset 0x150
+	// Capabilities: [150] Device Serial Number 88-dc-97-ff-ff-44-24-8b
+	const serialOffset = 0x150
+	_, err = file.Seek(serialOffset, 0)
+	if err != nil {
+		return "", fmt.Errorf("seek error to device serial number: %v", err)
+	}
+
+	// Read 8 bytes (64-bit serial number) - E.g. 88-dc-97-ff-ff-44-24-8b
+	buf := make([]byte, 8)
+	_, err = file.Read(buf)
+	if err != nil {
+		return "", fmt.Errorf("read error from device serial number: : %v", err)
+	}
+
+	// Convert raw bytes to hex string
+	serialHex := hex.EncodeToString(buf)
+	return serialHex, nil
 }
 
 type FakePlatform struct {
 	platformName string
 	devices      []*ghw.PCIDevice
+	netdevs      []*ghw.NIC
 	mu           sync.Mutex
 }
 
@@ -48,11 +97,31 @@ func (p *FakePlatform) PciDevices() ([]*ghw.PCIDevice, error) {
 	return p.devices, nil
 }
 
+func (p *FakePlatform) NetDevs() ([]*ghw.NIC, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.netdevs, nil
+}
+
 func (p *FakePlatform) Product() (*ghw.ProductInfo, error) {
 	return &ghw.ProductInfo{
 		Name: p.platformName,
 	}, nil
 }
+
+func (p *FakePlatform) ReadDeviceSerialNumber(pciDevice *ghw.PCIDevice) (string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if pciDevice == nil {
+		return "", fmt.Errorf("nil PCI device provided")
+	}
+
+	//TODO: Implement a more realistic serial number generation
+	return "FAKE-SERIAL-" + pciDevice.Address, nil
+}
+
 func (p *FakePlatform) RemoveAllPciDevices() {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -82,6 +82,14 @@ tasks:
         vars:
           KUBECONFIG: '{{.KUBECONFIG_HOST}}'
 
+  undeploy-1c:
+    vars:
+      KUBECONFIG_HOST: "/root/kubeconfig.ocpcluster"
+    deps:
+      - task: undeploy-helper
+        vars:
+          KUBECONFIG: '{{.KUBECONFIG_HOST}}'
+
   deploy-prep:
     internal: true
     deps:
@@ -114,6 +122,24 @@ tasks:
       - bin/kustomize build bin | KUBECONFIG="/root/kubeconfig.ocpcluster" oc apply -f -
       - KUBECONFIG="/root/kubeconfig.microshift" oc -n openshift-dpu-operator wait --for=condition=ready pod --all --timeout=300s
       - KUBECONFIG="/root/kubeconfig.ocpcluster" oc -n openshift-dpu-operator wait --for=condition=ready pod --all --timeout=300s
+
+  deploy-1c:
+    deps:
+      - task: deploy-prep
+    cmds:
+      - task: undeploy-1c
+        vars:
+          KUBECONFIG_HOST: "/root/kubeconfig.ocpcluster"
+      - bin/kustomize build bin | KUBECONFIG="/root/kubeconfig.ocpcluster" oc apply -f -
+      - KUBECONFIG="/root/kubeconfig.ocpcluster" oc -n openshift-dpu-operator wait --for=condition=ready pod --all --timeout=300s
+
+  prepare-e2e-test:
+    cmds:
+      - >
+        if [ "{{.SUBMODULES}}" = "true" ]; then
+            hack/prepare-submodules.sh
+        fi
+            hack/prepare-venv.sh
 
   e2e-test:
     deps:

--- a/taskfiles/binaries.yaml
+++ b/taskfiles/binaries.yaml
@@ -26,6 +26,12 @@ tasks:
     cmds:
       - GOOS={{.GOOS}} GOARCH={{.GOARCH}} go build -o {{.BINDIR}}/vsp-mrvl.{{.GOARCH}} internal/daemon/vendor-specific-plugins/marvell/main.go
 
+  build-bin-intel-netsec-vsp:
+    vars:
+      GOARCH: '{{.GOARCH}}'
+    cmds:
+      - GOOS={{.GOOS}} GOARCH={{.GOARCH}} go build -o {{.BINDIR}}/vsp-intel-netsec.{{.GOARCH}} internal/daemon/vendor-specific-plugins/intel-netsec/main.go
+
   build-bin-network-resources-injector:
     vars:
       GOARCH: '{{.GOARCH}}'

--- a/taskfiles/images.yaml
+++ b/taskfiles/images.yaml
@@ -237,6 +237,35 @@ tasks:
         vars:
           NAME: mrvl-cpagent
 
+  build-image-intel-netsec-vsp:
+    deps:
+      - task: build-bin-intel-netsec-vsp
+        vars:
+          GOARCH: arm64
+      - task: build-bin-intel-netsec-vsp
+        vars:
+          GOARCH: amd64
+      - task: clean-image-layer
+        vars:
+          NAME: intel-netsec-vsp
+    cmds:
+      - task: build-image
+        vars:
+          NAME: intel-netsec-vsp
+          DOCKERFILE: Dockerfile.IntelNetSecVSP.rhel
+          PLATFORM: amd64
+      - task: build-image
+        vars:
+          NAME: intel-netsec-vsp
+          DOCKERFILE: Dockerfile.IntelNetSecVSP.rhel
+          PLATFORM: arm64
+
+  clean-image-intel-netsec-vsp:
+    cmds:
+      - task: clean-image
+        vars:
+          NAME: intel-netsec-vsp
+
   build-image-intel-vsp:
     deps:
       - task: build-bin-intel-vsp
@@ -322,6 +351,7 @@ tasks:
       - task: clean-image-intel-vsp-p4
       - task: clean-image-marvell-vsp
       - task: clean-image-marvell-cpagent
+      - task: clean-image-intel-netsec-vsp
       - task: clean-image-network-resources-injector
 
   build-image-all:
@@ -332,6 +362,7 @@ tasks:
       - build-bin-daemon
       - build-bin-intel-vsp
       - build-bin-marvell-vsp
+      - build-bin-intel-netsec-vsp
       - build-bin-network-resources-injector
     cmds: # can't run in parallel since multiple concurrent pulls are not supported 
       - task: build-image-manager
@@ -339,12 +370,12 @@ tasks:
       - task: build-image-intel-vsp
       - task: build-image-intel-vsp-p4
       - task: build-image-marvell-vsp
+      - task: build-image-intel-netsec-vsp
       - task: build-image-marvell-cpagent
       - task: build-image-network-resources-injector
       - task: push-image-all
 
   push-image-all:
-    internal: true
     deps:
       - task: push-image-helper
         vars:
@@ -370,6 +401,10 @@ tasks:
         vars:
           SOURCE: 'localhost/intel-vsp-p4:dev'
           IMAGE: '{{.REGISTRY}}/intel-vsp-p4:dev'
+      - task: push-image-helper
+        vars:
+          SOURCE: 'localhost/intel-netsec-vsp:dev'
+          IMAGE: '{{.REGISTRY}}/intel-netsec-vsp:dev'
       - task: push-image-helper
         vars:
           SOURCE: 'localhost/network-resources-injector:dev'


### PR DESCRIPTION
This commit adds the intial PTL support for the DPU Operator. The goal of this commit is to have the daemon properly detect the Intel NetSec Accelerator. Then deploy the VSP properly. This commit deploys the operator in a 1 cluster mode. Which means all daemons and vsps run in 1 cluster for the host and the Intel NetSec Accelerator. There was changes to the taskfiles to achieve this.
    
Also remove duplication of code between Marvell and Intel NetSec by introducing the new vspnetutils and using platform and afero where appropriate.
    
For PTL we must use the PCIe Serial Number for the DPU Identifier. This is because the PTL has 2 PFs.
