### PR TITLE
OCPBUGS-58423: Fix Brew build issues for dpu-intel-ipu-vsp

### DIFF
--- a/openshift/install-dpu.sh
+++ b/openshift/install-dpu.sh
@@ -8,6 +8,7 @@ PIP_OPTS="--no-cache-dir"
 if [ -d ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps ]; then
     source ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env
     cd ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/app/openshift
+    export GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=16
 else
     cd  ${REMOTE_SOURCES_DIR}
 fi

--- a/openshift/requirements-build.txt
+++ b/openshift/requirements-build.txt
@@ -8,6 +8,7 @@ wheel==0.45.1
     # via -r ./requirements-pre-build.in
 flit-core==3.10.1
     # via -r ./requirements-build.in
+cython==3.0.0
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==75.6.0


### PR DESCRIPTION
`dpu-intel-ipu-vsp` is failing to build in Brew on aarch64 due to 2 issues:
- missing `cython` dependepcy 
- running out of memory while building wheel for `grpcio` package. grpcio by default uses all available CPUs for parallel compilation and Brew's aarch64 machines have 3 times more CPUs than the other machines, causing OOM errors.

This PR pins `cython` to 3.0.0 and limits the number of compiler jobs of grpcio build

Test build of this PR: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=68166504