### PR TITLE
[th/run-e2e-test-suite] e2e-test: add "run-e2e-test-suite.sh" script

### DIFF
--- a/hack/run-e2e-test-suite.sh
+++ b/hack/run-e2e-test-suite.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+
+die() {
+    printf '%s\n' "$*"
+    exit 1
+}
+
+cd "$(dirname "$0")/.." || die "failure to change directory for $0"
+
+export FAST_TEST="${FAST_TEST:-true}"
+export REGISTRY="${REGISTRY:-$(hostname | sed 's/$/:5000/')}"
+export NF_INGRESS_IP="${NF_INGRESS_IP:-10.20.30.2}"
+export EXTERNAL_CLIENT_DEV="${EXTERNAL_CLIENT_DEV:-eno12409}"
+export EXTERNAL_CLIENT_IP="${EXTERNAL_CLIENT_IP:-10.20.30.100}"
+export BINDIR="${BINDIR:-bin}"
+export ENVTEST_K8S_VERSION="${ENVTEST_K8S_VERSION:-$(sed -n 's/^ *ENVTEST_K8S_VERSION: \+\(.*\)$/\1/p' taskfile.yaml)}"
+
+BINDIR_ABS="$BINDIR"
+if [[ "$BINDIR_ABS" != /* ]] ; then
+    BINDIR_ABS="$PWD/$BINDIR"
+fi
+
+GINKO_ARGS=()
+
+if [ -n "$TEST_FOCUS" ] ; then
+    GINKO_ARGS+=( "-focus=${TEST_FOCUS}" )
+fi
+
+KUBEBUILDER_ASSETS="$( "$BINDIR/setup-envtest" use "$ENVTEST_K8S_VERSION" --bin-dir "$BINDIR_ABS" -p path )"
+export KUBEBUILDER_ASSETS
+
+run_test() {
+    "$BINDIR/ginkgo" -coverprofile cover.out "${GINKO_ARGS[@]}" ./e2e_test/...
+}
+
+rc=0
+run_test || rc="$?"
+
+if [ "$rc" != 0 ] ; then
+    echo ">>> Test failed. Rerun a few times!!"
+    for i in {1..5} ; do
+        echo ">>> Re-Run #$i..."
+        rc2=0
+        run_test || rc2=0
+        echo ">>> Re-Run #$i completed: result $rc2"
+    done
+fi
+
+exit "$rc"

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -134,13 +134,10 @@ tasks:
       - task: envtest
     cmds:
       - >
-        FAST_TEST=true
+        BINDIR={{.BINDIR}}
         REGISTRY={{.REGISTRY}}
-        NF_INGRESS_IP=10.20.30.2
-        EXTERNAL_CLIENT_DEV=eno12409
-        EXTERNAL_CLIENT_IP=10.20.30.100
-        KUBEBUILDER_ASSETS="$({{.BINDIR}}/setup-envtest use {{.ENVTEST_K8S_VERSION}} --bin-dir {{.BINDIR_ABS}} -p path)"
-        {{.BINDIR}}/ginkgo -coverprofile cover.out ./e2e_test/...
+        ENVTEST_K8S_VERSION={{.ENVTEST_K8S_VERSION}}
+        hack/run-e2e-test-suite.sh
       - hack/traffic_flow_tests.sh
 
   prepare-e2e-test:


### PR DESCRIPTION
Benefits:

- when the primary/first run of the test fails, the script will re-run the test a few times more. This is useful to see whether the test would pass, if it would run again (e.g. a fluke). In any case, the overall run will be a failure, even if all the re-runs pass.

- environment variables like EXTERNAL_CLIENT_DEV can be set by the caller to overwrite the settings (e.g. to test on a cluster with a different setup).

- supports TEST_FOCUS variable.

- hack/run-e2e-test-suite.sh can be run directly, without the task file. In particular, you can run only the e2e-test suite, without the traffic-flow-tests (unlike `task run-e2e-test`).