### PR TITLE
[th/e2e-test-timeout-sfc-running] e2e-test: increase timeout waiting for SFC Pod to be "Running"

### DIFF
--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -35,10 +35,11 @@ var (
 	cfg     *rest.Config
 	testEnv *envtest.Environment
 	// TODO: reduce to 2 seconds
-	timeout  = 1 * time.Minute
-	interval = 1 * time.Second
-	nfName   = "test-nf"
-	sfcName  = "sfc-test"
+	timeout                 = 1 * time.Minute
+	timeout_sfc_pod_running = 2 * time.Minute
+	interval                = 1 * time.Second
+	nfName                  = "test-nf"
+	sfcName                 = "sfc-test"
 )
 
 func pingTest(srcClientSet kubernetes.Interface, srcRestConfig *rest.Config, srcPod *corev1.Pod, destIP, srcName, destName string) {
@@ -410,7 +411,7 @@ var _ = g.Describe("E2E integration testing", g.Ordered, func() {
 				err = dpuSideClient.List(context.TODO(), podList, client.InNamespace(vars.Namespace))
 				Expect(err).NotTo(HaveOccurred())
 
-				nfPod = testutils.EventuallyPodIsRunning(dpuSideClient, nfName, vars.Namespace, timeout, interval)
+				nfPod = testutils.EventuallyPodIsRunning(dpuSideClient, nfName, vars.Namespace, timeout_sfc_pod_running, interval)
 
 				Expect(nfPod.Spec.Containers[0].Image).To(Equal(imageRef), "Pod should have expected image")
 


### PR DESCRIPTION
Probably due to IIC-641, it can take a long time for the SFC pod to be running. The current timeout of one minute is not long enough. See for example [1].

Increase the timeout.

See-also: https://issues.redhat.com/browse/IIC-641
[1] https://jenkins-csb-nst-net-hw-ci.dno.corp.redhat.com/view/DPU%20Testing/job/Dpu_Operator_Nightly_E2E_Test/1255/console

Fixes: https://issues.redhat.com/browse/IIC-651

--

See-also: https://issues.redhat.com/browse/IIC-651?focusedId=27598453&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-27598453