### PR TITLE
IPU plugin version update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-task/task/v3 v3.43.3
 	github.com/golang/glog v1.2.4
 	github.com/gorilla/mux v1.8.1
-	github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250703025056-a295ef3984ae
+	github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250722202314-5c941620a662
 	github.com/jaypipes/ghw v0.13.1-0.20241024164530-c1bfc6e6cd6a
 	github.com/k8snetworkplumbingwg/cni-log v0.0.0-20230801160229-b6e062c9e0f2
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+h
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250703025056-a295ef3984ae h1:WmCKA46Elyc/NU1BQnmSfr5JlDFqTyUMJ2F3KcvZKsw=
-github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250703025056-a295ef3984ae/go.mod h1:lzsjdWjRhMYe4nju1zWU8QL2MQG/jsAX6VMkD7iyCK4=
+github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250722202314-5c941620a662 h1:3pnPxZWYGBSJfzOJAjcJRUqW6j5qxfrIxh+eROmAixo=
+github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250722202314-5c941620a662/go.mod h1:lzsjdWjRhMYe4nju1zWU8QL2MQG/jsAX6VMkD7iyCK4=
 github.com/jaypipes/ghw v0.13.1-0.20241024164530-c1bfc6e6cd6a h1:orxBMCkYww7RFCk3iCDP9DC3l+yKtp4VdWtctCTyjPQ=
 github.com/jaypipes/ghw v0.13.1-0.20241024164530-c1bfc6e6cd6a/go.mod h1:F4UM7Ix55ONYwD3Lck2S4BI+hKezOwtizuJxXDFsioo=
 github.com/jaypipes/pcidb v1.0.1 h1:WB2zh27T3nwg8AE8ei81sNRb9yWBii3JGNJtT7K9Oic=

--- a/vendor/github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
+++ b/vendor/github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/ipuplugin/lifecycleservice.go
@@ -64,10 +64,10 @@ var PeerToPeerP4RulesAdded = false
 
 // Reserved ACC interfaces(using vport_id or last digit of interface name, like 4 represents-> enp0s1f0d4)
 const (
-	PHY_PORT0_PRIMARY_INTF_INDEX    = 1
-	PHY_PORT0_SECONDARY_INTF_INDEX  = 4
-	NF_IN_PR_INTF_INDEX             = 9
-	NF_OUT_PR_INTF_INDEX            = 10
+	PHY_PORT0_PRIMARY_INTF_INDEX   = 1
+	PHY_PORT0_SECONDARY_INTF_INDEX = 4
+	NF_IN_PR_INTF_INDEX            = 9
+	NF_OUT_PR_INTF_INDEX           = 10
 )
 
 // TODO: GetFilteredPFs can be used to fill the array.

--- a/vendor/github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/p4rtclient/p4rtclient.go
+++ b/vendor/github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/p4rtclient/p4rtclient.go
@@ -270,11 +270,11 @@ func deletePhyVportBridgeId(p4rtClient types.P4RTClient, phyPort, bridgeId int) 
 }
 
 func programNfPrVportP4Rules(p4rtClient types.P4RTClient, ingressMac, egressMac string) error {
-	ingressVsi, ingressVport, err := utils.GetVsiVportInfo(ingressMac)
+	ingressVsi, ingressVport, err := utils.ExtractVsiVportInfo(ingressMac)
 	if err != nil {
 		return fmt.Errorf("programNfPrVportP4Rules failed. Unable to find Vsi and Vport for NF ingress mac: %v", ingressMac)
 	}
-	egressVsi, egressVport, err := utils.GetVsiVportInfo(egressMac)
+	egressVsi, egressVport, err := utils.ExtractVsiVportInfo(egressMac)
 	if err != nil {
 		return fmt.Errorf("programNfPrVportP4Rules failed. Unable to find Vsi and Vport for NF egress mac: %v", egressMac)
 	}
@@ -340,11 +340,11 @@ func programNfPrVportP4Rules(p4rtClient types.P4RTClient, ingressMac, egressMac 
 }
 
 func deleteNfPrVportP4Rules(p4rtClient types.P4RTClient, ingressMac, egressMac string) error {
-	ingressVsi, ingressVport, err := utils.GetVsiVportInfo(ingressMac)
+	ingressVsi, ingressVport, err := utils.ExtractVsiVportInfo(ingressMac)
 	if err != nil {
 		return fmt.Errorf("deleteNfPrVportP4Rules failed. Unable to find Vsi and Vport for NF ingress mac: %v", ingressMac)
 	}
-	egressVsi, _, err := utils.GetVsiVportInfo(egressMac)
+	egressVsi, _, err := utils.ExtractVsiVportInfo(egressMac)
 	if err != nil {
 		return fmt.Errorf("deleteNfPrVportP4Rules failed. Unable to find Vsi and Vport for NF ingress mac: %v", egressMac)
 	}
@@ -410,12 +410,12 @@ func deleteNfPrVportP4Rules(p4rtClient types.P4RTClient, ingressMac, egressMac s
 }
 
 func programVsiToVsiP4Rules(p4rtClient types.P4RTClient, mac1, mac2 string) error {
-	mac1Vsi, mac1Vport, err := utils.GetVsiVportInfo(mac1)
+	mac1Vsi, mac1Vport, err := utils.ExtractVsiVportInfo(mac1)
 	if err != nil {
 		return fmt.Errorf("programVsiToVsiP4Rules failed. Unable to find Vsi and Vport for mac: %v", mac1)
 	}
 
-	mac2Vsi, mac2Vport, err := utils.GetVsiVportInfo(mac2)
+	mac2Vsi, mac2Vport, err := utils.ExtractVsiVportInfo(mac2)
 	if err != nil {
 		return fmt.Errorf("programVsiToVsiP4Rules failed. Unable to find Vsi and Vport for mac: %v", mac2)
 	}
@@ -444,12 +444,12 @@ func programVsiToVsiP4Rules(p4rtClient types.P4RTClient, mac1, mac2 string) erro
 }
 
 func deleteVsiToVsiP4Rules(p4rtClient types.P4RTClient, mac1, mac2 string) error {
-	mac1Vsi, _, err := utils.GetVsiVportInfo(mac1)
+	mac1Vsi, _, err := utils.ExtractVsiVportInfo(mac1)
 	if err != nil {
 		return fmt.Errorf("deleteVsiToVsiP4Rules failed. Unable to find Vsi and Vport for mac: %v", mac1)
 	}
 
-	mac2Vsi, _, err := utils.GetVsiVportInfo(mac2)
+	mac2Vsi, _, err := utils.ExtractVsiVportInfo(mac2)
 	if err != nil {
 		return fmt.Errorf("deleteVsiToVsiP4Rules failed. Unable to find Vsi and Vport for mac: %v", mac2)
 	}
@@ -607,6 +607,8 @@ func (p *p4rtclient) getDelRuleSets(macAddr []byte, vlan int) []fxpRuleParams {
 	return ruleSets
 }
 
+// P4 APIs exposed to ipu-opi-plugins
+
 func AddPhyPortRules(p4rtClient types.P4RTClient, prP0mac string, prP1mac string) error {
 	macAddr, macErr := checkMacAddresses(prP0mac, prP1mac)
 	if macErr != nil {
@@ -658,12 +660,12 @@ func AddHostVfP4Rules(p4rtClient types.P4RTClient, hostVfMac []byte, accMac stri
 		return errors.New("Invalid Mac Address")
 	}
 
-	hostVfVsi, hostVfVport, err := utils.GetVsiVportInfo(hostMacAddr.String())
+	hostVfVsi, hostVfVport, err := utils.ExtractVsiVportInfo(hostMacAddr.String())
 	if err != nil {
 		return fmt.Errorf("AddHostVfP4Rules failed. Unable to find Vsi and Vport for mac: %v", hostMacAddr.String())
 	}
 
-	apfPrVsi, apfPrVport, err := utils.GetVsiVportInfo(accMac)
+	apfPrVsi, apfPrVport, err := utils.ExtractVsiVportInfo(accMac)
 	if err != nil {
 		return fmt.Errorf("AddHostVfP4Rules failed. Unable to find Vsi and Vport for mac: %v", accMac)
 	}
@@ -744,12 +746,12 @@ func DeleteHostVfP4Rules(p4rtClient types.P4RTClient, hostVfMac []byte, accMac s
 		return errors.New("Invalid Mac Address")
 	}
 
-	hostVfVsi, hostVfVport, err := utils.GetVsiVportInfo(hostMacAddr.String())
+	hostVfVsi, hostVfVport, err := utils.ExtractVsiVportInfo(hostMacAddr.String())
 	if err != nil {
 		return fmt.Errorf("DeleteHostVfP4Rules failed. Unable to find Vsi and Vport for mac: %v", hostMacAddr.String())
 	}
 
-	apfPrVsi, _, err := utils.GetVsiVportInfo(accMac)
+	apfPrVsi, _, err := utils.ExtractVsiVportInfo(accMac)
 	if err != nil {
 		return fmt.Errorf("DeleteHostVfP4Rules failed. Unable to find Vsi and Vport for mac: %v", accMac)
 	}

--- a/vendor/github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/utils/utils.go
+++ b/vendor/github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/utils/utils.go
@@ -73,6 +73,17 @@ func ExecOsCommand(cmdBin string, params ...string) error {
 	return nil
 }
 
+func ExtractVsiVportInfo(macAddr string) (int, int, error) {
+	macAddrByte, err := GetMacAsByteArray(macAddr)
+	if err != nil {
+		log.Info("ExtractVsiVportInfo failed.", macAddr)
+		return 0, 0, err
+	}
+	vfVsi := int(macAddrByte[1])
+	vfVport := GetVportForVsi(vfVsi)
+	return vfVsi, vfVport, nil
+}
+
 func GetVsiVportInfo(macAddr string) (int, int, error) {
 	vsi, err := ImcQueryfindVsiGivenMacAddr(types.IpuMode, macAddr)
 	if err != nil {
@@ -491,9 +502,9 @@ func CopyBinary(imcPath string, vspPath string, sftpClient *sftp.Client) error {
 }
 
 func RestoreRHPrimaryNetwork() {
-        remoteCliCmd := "set -o pipefail && /work/scripts/post_init_app.sh"
+	remoteCliCmd := "set -o pipefail && /work/scripts/post_init_app.sh"
 	_, err := RunCliCmdOnImc(remoteCliCmd, "")
-        if err != nil {
-               log.Info("RunCliCmdOnImc: Warning!. Unable to restore primary network access for to this IPU-ACC")
-        }
+	if err != nil {
+		log.Info("RunCliCmdOnImc: Warning!. Unable to restore primary network access for to this IPU-ACC")
+	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -533,7 +533,7 @@ github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.1.0
 ## explicit; go 1.18
 github.com/inconshreveable/mousetrap
-# github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250703025056-a295ef3984ae
+# github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250722202314-5c941620a662
 ## explicit; go 1.23.6
 github.com/intel/ipu-opi-plugins/ipu-plugin/ipuplugin/cmd
 github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/infrapod


### PR DESCRIPTION
This version addresses slow progression of Host and IPU pod creation/deletion flow due to extended delays in P4 rule updates at IPU.

We now derive the VSI and vPort directly from the VF’s MAC address. Previously, we queried the IMC in real time during P4 rule programming, which added latency to rule add/delete APIs and slowed NF and host pod provisioning.

This update eliminates those frequent IMC calls for VFs, while we continue to query IMC for PHY interfaces (primary/secondary networks) since their MACs can be statically configured via NVMe.

Refer IIC-641 for more context.