### PR TITLE
Detect DPUs and represent them in memory

### DIFF
--- a/Dockerfile.daemon.rhel
+++ b/Dockerfile.daemon.rhel
@@ -25,7 +25,7 @@ COPY --from=builder /workspace/bin/daemon.${TARGETARCH} daemon
 COPY --from=builder /workspace/bin/dpu-cni.${TARGETARCH} dpu-cni
 
 # Install the hwdata package to include pci.ids to ensure jaypipes/ghw can run offline
-RUN yum install -y hwdata && yum clean all
+RUN yum install -y hwdata ethtool && yum clean all
 
 USER 65532:65532
 

--- a/internal/controller/bindata/daemon/99.daemonset.yaml
+++ b/internal/controller/bindata/daemon/99.daemonset.yaml
@@ -62,6 +62,8 @@ spec:
           mountPropagation: Bidirectional
         - name: proc
           mountPath: /proc
+        - name: sys
+          mountPath: /sys
         args:
         - --mode
         - {{.Mode}}
@@ -81,3 +83,6 @@ spec:
         - name: proc
           hostPath:
             path: /proc/
+        - name: sys
+          hostPath:
+            path: /sys/

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -21,7 +21,7 @@ import (
 var ()
 
 type SideManager interface {
-	StartVsp() error
+	StartVsp(ctx context.Context) error
 	SetupDevices() error
 	Listen() (net.Listener, error)
 	Serve(ctx context.Context, listen net.Listener) error
@@ -38,6 +38,7 @@ type Daemon struct {
 	fs                afero.Fs
 	p                 platform.Platform
 	dpuDetectorManger *platform.DpuDetectorManager
+	detectedDpus      map[string]platform.DetectedDpu
 }
 
 func NewDaemon(fs afero.Fs, p platform.Platform, mode string, config *rest.Config, imageManager images.ImageManager, pathManager *utils.PathManager) Daemon {
@@ -52,6 +53,7 @@ func NewDaemon(fs afero.Fs, p platform.Platform, mode string, config *rest.Confi
 		p:                 p,
 		dpuDetectorManger: platform.NewDpuDetectorManager(p),
 		managers:          make([]SideManager, 0),
+		detectedDpus:      make(map[string]platform.DetectedDpu),
 	}
 }
 
@@ -96,57 +98,45 @@ func (d *Daemon) Serve(ctx context.Context) error {
 	for {
 		select {
 		case <-ticker.C:
-			if len(d.managers) >= 1 {
-				continue
-			}
-			d.log.Info("Scanning for DPUs")
-			sideManager, err := d.createDaemon()
+			detectedDpusList, err := d.dpuDetectorManger.DetectAll(d.imageManager, d.client, *d.pm)
+			currentDpus := d.detectedDpusToMap(detectedDpusList)
 			if err != nil {
 				d.log.Error(err, "Got error while detecting DPUs")
 				return err
 			}
-			if sideManager != nil {
+
+			if len(currentDpus) > 1 {
+				var keys []string
+				for key := range currentDpus {
+					keys = append(keys, key)
+				}
+				err := fmt.Errorf("Detected %d DPUs, but only one is currently supported", len(currentDpus))
+				d.log.Error(err, "Got error while detecting DPUs", "dpuKeys", keys)
+				return err
+			}
+
+			newDpus := d.findNewDpus(d.detectedDpus, currentDpus)
+
+			for _, dpu := range newDpus {
+				sideManager, err := d.createSideManager(dpu)
+				if err != nil {
+					d.log.Error(err, "Got error while creating side manager")
+					return err
+				}
 				d.managers = append(d.managers, sideManager)
+
 				done := make(chan struct{})
 				managerDone = append(managerDone, done)
-				go func(mgr SideManager) {
-					defer close(done)
-					err := mgr.StartVsp()
+				go func(mgr SideManager, doneChannel chan struct{}) {
+					defer close(doneChannel)
+					err := d.runSideManager(mgr, managerCtx)
 					if err != nil {
-						d.log.Error(err, "Failed to start VSP in sideManager")
-						select {
-						case errChan <- err:
-						default:
-						}
-						return
-					}
-					err = mgr.SetupDevices()
-					if err != nil {
-						d.log.Error(err, "Failed to setup devices in sideManager")
-						select {
-						case errChan <- err:
-						default:
-						}
-						return
-					}
-					listener, err := mgr.Listen()
-					if err != nil {
-						d.log.Error(err, "Failed to listen on sideManager")
-						select {
-						case errChan <- err:
-						default:
-						}
-						return
-					}
-					err = mgr.Serve(managerCtx, listener)
-					if err != nil && managerCtx.Err() == nil {
-						d.log.Error(err, "Failed to serve on sideManager")
 						select {
 						case errChan <- err:
 						default:
 						}
 					}
-				}(sideManager)
+				}(sideManager, done)
 			}
 		case err := <-errChan:
 			d.log.Error(err, "Side manager failed, stopping all managers")
@@ -169,27 +159,42 @@ func (d *Daemon) Serve(ctx context.Context) error {
 	}
 }
 
-func (d *Daemon) createDaemon() (SideManager, error) {
-	dpuMode, plugin, err := d.dpuDetectorManger.Detect(d.imageManager, d.client, *d.pm)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to detect DPUs: %v", err)
+func (d *Daemon) detectedDpusToMap(detectedDpusList []platform.DetectedDpu) map[string]platform.DetectedDpu {
+	detectedDpus := make(map[string]platform.DetectedDpu)
+	for _, detectedDpu := range detectedDpusList {
+		key := string(detectedDpu.Identifier)
+		detectedDpus[key] = detectedDpu
 	}
-	if plugin != nil {
-		if dpuMode {
-			dsm, err := NewDpuSideManager(plugin, d.config, WithPathManager(*d.pm))
-			if err != nil {
-				return nil, fmt.Errorf("failed to create DpuSideManager: %v", err)
-			}
-			return dsm, nil
+	return detectedDpus
+}
+
+func (d *Daemon) findNewDpus(previousDpus map[string]platform.DetectedDpu, currentDpus map[string]platform.DetectedDpu) []platform.DetectedDpu {
+	var newDpus []platform.DetectedDpu
+	for key, detectedDpu := range currentDpus {
+		if _, exists := previousDpus[key]; !exists {
+			d.log.Info("New DPU detected", "identifier", key, "isDpuPlatform", detectedDpu.IsDpuPlatform)
+			d.detectedDpus[key] = detectedDpu
+			newDpus = append(newDpus, detectedDpu)
 		} else {
-			hsm, err := NewHostSideManager(plugin, WithPathManager2(d.pm))
-			if err != nil {
-				return nil, fmt.Errorf("failed to create HostSideManager: %v", err)
-			}
-			return hsm, nil
 		}
 	}
-	return nil, nil
+	return newDpus
+}
+
+func (d *Daemon) createSideManager(detectedDpu platform.DetectedDpu) (SideManager, error) {
+	if detectedDpu.IsDpuPlatform {
+		dsm, err := NewDpuSideManager(detectedDpu.Plugin, d.config, WithPathManager(*d.pm))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create DpuSideManager: %v", err)
+		}
+		return dsm, nil
+	} else {
+		hsm, err := NewHostSideManager(detectedDpu.Plugin, WithPathManager2(d.pm))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create HostSideManager: %v", err)
+		}
+		return hsm, nil
+	}
 }
 
 func (d *Daemon) prepareCni() error {
@@ -205,5 +210,29 @@ func (d *Daemon) prepareCni() error {
 		return err
 	}
 	d.log.Info("Prepared CNI binary", "path", cniPath)
+	return nil
+}
+
+func (d *Daemon) runSideManager(mgr SideManager, managerCtx context.Context) error {
+	err := mgr.StartVsp(managerCtx)
+	if err != nil {
+		d.log.Error(err, "Failed to start VSP in sideManager")
+		return err
+	}
+	err = mgr.SetupDevices()
+	if err != nil {
+		d.log.Error(err, "Failed to setup devices in sideManager")
+		return err
+	}
+	listener, err := mgr.Listen()
+	if err != nil {
+		d.log.Error(err, "Failed to listen on sideManager")
+		return err
+	}
+	err = mgr.Serve(managerCtx, listener)
+	if err != nil && managerCtx.Err() == nil {
+		d.log.Error(err, "Failed to serve on sideManager")
+		return err
+	}
 	return nil
 }

--- a/internal/daemon/dpusidemanager.go
+++ b/internal/daemon/dpusidemanager.go
@@ -83,8 +83,8 @@ func WithPathManager(pathManager utils.PathManager) func(*DpuSideManager) {
 	}
 }
 
-func (d *DpuSideManager) StartVsp() error {
-	addr, port, err := d.vsp.Start()
+func (d *DpuSideManager) StartVsp(ctx context.Context) error {
+	addr, port, err := d.vsp.Start(ctx)
 	if err != nil {
 		return fmt.Errorf("failed calling VSP Start() from DpuSideManager: %v", err)
 	}

--- a/internal/daemon/dpusidemanager_test.go
+++ b/internal/daemon/dpusidemanager_test.go
@@ -82,7 +82,7 @@ var _ = g.Describe("DPU side manager", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 		dpuDaemon, err = NewDpuSideManager(dpuPlugin, config, WithPathManager(pathManager))
 		Expect(err).NotTo(HaveOccurred())
-		err = dpuDaemon.StartVsp()
+		err = dpuDaemon.StartVsp(context.Background())
 		Expect(err).NotTo(HaveOccurred())
 		err = dpuDaemon.SetupDevices()
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/daemon/hostsidemanager.go
+++ b/internal/daemon/hostsidemanager.go
@@ -119,10 +119,10 @@ func WithClient(client *rest.Config) func(*HostSideManager) {
 	}
 }
 
-func (d *HostSideManager) StartVsp() error {
-	addr, port, err := d.vsp.Start()
+func (d *HostSideManager) StartVsp(ctx context.Context) error {
+	addr, port, err := d.vsp.Start(ctx)
 	if err != nil {
-		return fmt.Errorf("failed calling VSP Start(): %v", err)
+		return fmt.Errorf("failed calling VSP Start() from HostSideManager: %v", err)
 	}
 	d.addr = addr
 	d.port = port

--- a/internal/daemon/hostsidemanager_test.go
+++ b/internal/daemon/hostsidemanager_test.go
@@ -47,7 +47,7 @@ func NewDummyPlugin() *DummyPlugin {
 	return &DummyPlugin{}
 }
 
-func (v *DummyPlugin) Start() (string, int32, error) {
+func (v *DummyPlugin) Start(ctx context.Context) (string, int32, error) {
 	return "127.0.0.1", 50051, nil
 }
 
@@ -215,7 +215,7 @@ var _ = g.Describe("Host Daemon", func() {
 		m := SriovManagerStub{}
 		hostDaemon, err = NewHostSideManager(dummyPluginHost, WithPathManager2(pathManager), WithSriovManager(m), WithClient(client))
 		Expect(err).NotTo(HaveOccurred())
-		err = hostDaemon.StartVsp()
+		err = hostDaemon.StartVsp(context.Background())
 		Expect(err).NotTo(HaveOccurred())
 		err = hostDaemon.SetupDevices()
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/daemon/vendor-specific-plugins/common/vspnetutils.go
+++ b/internal/daemon/vendor-specific-plugins/common/vspnetutils.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openshift/dpu-operator/internal/platform"
 	"github.com/spf13/afero"
 	"github.com/vishvananda/netlink"
 	"k8s.io/klog/v2"
@@ -118,24 +117,6 @@ func EnableIPV6LinkLocal(fs afero.Fs, interfaceName string, ipv6Addr string) err
 		return fmt.Errorf("error configuring IPv6 address %s/64 on link %s: %v", ipv6Addr, interfaceName, err)
 	}
 	return nil
-}
-
-// GetNetDevNameFromPCIeAddr retrieves the network device name associated with a given PCIe address.
-// This can fail if the given PCIe address is not a NetDev or the driver is not loaded correctly.
-func GetNetDevNameFromPCIeAddr(platform platform.Platform, pcieAddress string) (string, error) {
-	nics, err := platform.NetDevs()
-	if err != nil {
-		return "", fmt.Errorf("failed to get network devices: %w", err)
-	}
-
-	for _, nic := range nics {
-		if nic.PCIAddress != nil && *nic.PCIAddress == pcieAddress {
-			klog.Infof("GetNetDevNameFromPCIeAddr(): found DPU network device %s %s", nic.Name, *nic.PCIAddress)
-			return nic.Name, nil
-		}
-	}
-
-	return "", fmt.Errorf("network device not found for PCI address %s", pcieAddress)
 }
 
 func CreateNfVethPair(idx int) (*VEthPairDeviceInfo, error) {

--- a/internal/daemon/vendor-specific-plugins/intel-netsec/main.go
+++ b/internal/daemon/vendor-specific-plugins/intel-netsec/main.go
@@ -98,14 +98,14 @@ func (vsp *intelNetSecVspServer) configureCommChannelIPs(dpuMode bool) (pb.IpPor
 	var err error
 	if dpuMode {
 		// All NetSec DPU devices have the same internal PCIe Addresses. Netdev names can change with each RHEL release.
-		ifName, err = vspnetutils.GetNetDevNameFromPCIeAddr(vsp.platform, IntelNetSecDpuBackplanef2PCIeAddress)
+		ifName, err = vsp.platform.GetNetDevNameFromPCIeAddr(IntelNetSecDpuBackplanef2PCIeAddress)
 		if err != nil {
 			vsp.log.Error(err, "Error getting netdev name from PCIe address in DPU mode", "PCIeAddress", IntelNetSecDpuBackplanef2PCIeAddress)
 			return pb.IpPort{}, err
 		}
 		addr = IPv6AddrDpu
 	} else {
-		ifName, err = vspnetutils.GetNetDevNameFromPCIeAddr(vsp.platform, vsp.dpuPcieAddress)
+		ifName, err = vsp.platform.GetNetDevNameFromPCIeAddr(vsp.dpuPcieAddress)
 		if err != nil {
 			vsp.log.Error(err, "Error getting netdev name from PCIe address in Host mode", "PCIeAddress", vsp.dpuPcieAddress)
 			return pb.IpPort{}, err
@@ -184,7 +184,7 @@ func (vsp *intelNetSecVspServer) initOvSDataPlane(bridgeName string) error {
 	// 1. IntelNetSecDpuSFPf0PCIeAddress can be used for the cluster network.
 	// 2. IntelNetSecDpuSFPf1PCIeAddress we use the second 25Gbe interface for now.
 	// With 1) you can't have the same interface on 2 bridges.
-	sfpPortIfName, err := vspnetutils.GetNetDevNameFromPCIeAddr(vsp.platform, IntelNetSecDpuSFPf1PCIeAddress)
+	sfpPortIfName, err := vsp.platform.GetNetDevNameFromPCIeAddr(IntelNetSecDpuSFPf1PCIeAddress)
 	if err != nil {
 		vsp.log.Error(err, "Error occurred in getting SFP Port Interface Name", "PCIeAddress", IntelNetSecDpuSFPf1PCIeAddress)
 		return err
@@ -322,7 +322,7 @@ func (vsp *intelNetSecVspServer) getConnectedVf(OPIBridgePortName string) (*vspn
 		return nil, err
 	}
 
-	pfIfName, err := vspnetutils.GetNetDevNameFromPCIeAddr(vsp.platform, backPlanePcieAddr)
+	pfIfName, err := vsp.platform.GetNetDevNameFromPCIeAddr(backPlanePcieAddr)
 	if err != nil {
 		vsp.log.Error(err, "Error getting netdev name from PCIe address", "PCIeAddress", backPlanePcieAddr)
 		return nil, err
@@ -353,7 +353,7 @@ func (vsp *intelNetSecVspServer) CreateBridgePort(ctx context.Context, in *opi.C
 		return nil, err
 	}
 
-	vfIfName, err := vspnetutils.GetNetDevNameFromPCIeAddr(vsp.platform, vfDevice.PciAddress)
+	vfIfName, err := vsp.platform.GetNetDevNameFromPCIeAddr(vfDevice.PciAddress)
 	if err != nil {
 		vsp.log.Error(err, "Error getting netdev name from PCIe address", "PCIeAddress", vfDevice.PciAddress)
 		return nil, err
@@ -379,7 +379,7 @@ func (vsp *intelNetSecVspServer) DeleteBridgePort(ctx context.Context, in *opi.D
 		return nil, err
 	}
 
-	vfIfName, err := vspnetutils.GetNetDevNameFromPCIeAddr(vsp.platform, vfDevice.PciAddress)
+	vfIfName, err := vsp.platform.GetNetDevNameFromPCIeAddr(vfDevice.PciAddress)
 	if err != nil {
 		vsp.log.Error(err, "Error getting netdev name from PCIe address", "PCIeAddress", vfDevice.PciAddress)
 		return nil, err
@@ -423,7 +423,7 @@ func (vsp *intelNetSecVspServer) setVlanIdsSpoofChk(numVfs int) error {
 		pcieAddr = vsp.dpuPcieAddress
 	}
 
-	ifName, err = vspnetutils.GetNetDevNameFromPCIeAddr(vsp.platform, pcieAddr)
+	ifName, err = vsp.platform.GetNetDevNameFromPCIeAddr(pcieAddr)
 	if err != nil {
 		vsp.log.Error(err, "Error getting netdev name from PCIe address", "PCIeAddress", pcieAddr)
 		return err

--- a/internal/platform/marvell-dpu.go
+++ b/internal/platform/marvell-dpu.go
@@ -1,6 +1,8 @@
 package platform
 
 import (
+	"fmt"
+
 	"github.com/jaypipes/ghw"
 	"github.com/openshift/dpu-operator/internal/daemon/plugin"
 	"github.com/openshift/dpu-operator/internal/images"
@@ -56,8 +58,8 @@ func (pi *MarvellDetector) IsDpuPlatform(platform Platform) (bool, error) {
 }
 
 func (pi *MarvellDetector) GetDpuIdentifier(platform Platform, pci *ghw.PCIDevice) (plugin.DpuIdentifier, error) {
-	// TODO: Implement a way to get the DPU identifier.
-	return "", nil
+	identifier := fmt.Sprintf("marvell-dpu-%s", pci.Address)
+	return plugin.DpuIdentifier(identifier), nil
 }
 
 func (pi *MarvellDetector) VspPlugin(dpuMode bool, imageManager images.ImageManager, client client.Client, pm utils.PathManager, dpuIdentifier plugin.DpuIdentifier) (*plugin.GrpcPlugin, error) {


### PR DESCRIPTION
This commit makes the final adjustments needed for the in-memory DPU list to be represented as Kubernetes Custom Resources (CRs). The changes are as follows:

* **Fixed a context-based side manager race:** A previous 10-second timeout was too short for the VSP to start, so the connection logic now blocks forever until the connection is established. The next PR will report the DPU CR as `NotReady` until the connection is fully established.
* **Added initial multi-DPU support:** The code is being prepared for future support of multiple DPUs, even though VSPs don't support it yet. For now, it will error out if more than one DPU is detected.
* **Refactored manager completion logic:** The logic for handling manager completion was refactored. The `done` variable is now passed directly to the function, which improves readability and removes the need for a closure. In the past, the `done` variable was captured because the logic was defined in line.

The goal of this commit is to handle the logic changes separately from the Kubernetes boilerplate code. This makes the review process for both changes much simpler. The next PR will sync the detected DPU list into k8s.