### PR TITLE
feat: Change the flavour focus away from microshift vs openshift

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -115,5 +115,14 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
+        volumeMounts:
+        - name: host-run
+          mountPath: /host-run
+          readOnly: true
+      volumes:
+      - name: host-run
+        hostPath:
+          path: /run
+          type: DirectoryOrCreate
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/internal/controller/dpuoperatorconfig_controller.go
+++ b/internal/controller/dpuoperatorconfig_controller.go
@@ -138,8 +138,19 @@ func (r *DpuOperatorConfigReconciler) yamlVars() map[string]string {
 		return nil
 	}
 	logger.Info("Detected Kuberentes flavour", "flavour", flavour)
-	p, err := r.pathManager.CniHostDir(flavour)
+
+	logger.Info("Detecting filesystem deployment mode")
+	fmd := utils.NewFilesystemModeDetector()
+	filesystemMode, err := fmd.DetectMode()
 	if err != nil {
+		logger.Error(err, "Failed to detect filesystem mode")
+		return nil
+	}
+	logger.Info("Detected filesystem deployment mode", "mode", filesystemMode)
+
+	p, err := r.pathManager.CniHostDir(flavour, filesystemMode)
+	if err != nil {
+		logger.Error(err, "Failed to determine CNI host directory", "flavour", flavour, "filesystemMode", filesystemMode)
 		return nil
 	}
 

--- a/internal/utils/filesystem_mode_detector.go
+++ b/internal/utils/filesystem_mode_detector.go
@@ -1,0 +1,86 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/afero"
+)
+
+// FilesystemMode represents the deployment mode of the operating system
+type FilesystemMode string
+
+const (
+	// ImageMode represents immutable, image-based deployment (OSTree, etc.)
+	ImageMode FilesystemMode = "ImageMode"
+	// PackageMode represents traditional, package-based deployment (rpm, deb, etc.)
+	PackageMode FilesystemMode = "PackageMode"
+)
+
+// FilesystemModeDetector detects whether the operating system uses
+// image-based deployment (immutable) or package-based deployment (mutable)
+type FilesystemModeDetector struct {
+	fs afero.Fs
+}
+
+// NewFilesystemModeDetector creates a new FilesystemModeDetector with the OS filesystem
+func NewFilesystemModeDetector() *FilesystemModeDetector {
+	return &FilesystemModeDetector{
+		fs: afero.NewOsFs(),
+	}
+}
+
+// NewFilesystemModeDetectorWithFs creates a FilesystemModeDetector with a custom filesystem interface.
+// This is primarily used for testing with mock filesystems.
+func NewFilesystemModeDetectorWithFs(fs afero.Fs) *FilesystemModeDetector {
+	return &FilesystemModeDetector{
+		fs: fs,
+	}
+}
+
+// DetectMode returns the current filesystem deployment mode
+func (fmd *FilesystemModeDetector) DetectMode() (FilesystemMode, error) {
+	isImageMode, err := fmd.IsImageMode()
+	if err != nil {
+		return "", err
+	}
+
+	if isImageMode {
+		return ImageMode, nil
+	}
+	return PackageMode, nil
+}
+
+// IsImageMode checks if the OS uses immutable image-based deployment
+// Currently detects OSTree-based systems, but could be extended for other image-based systems
+func (fmd *FilesystemModeDetector) IsImageMode() (bool, error) {
+	// When running in the controller container, check the mounted host path
+	// Otherwise, check the local path (for daemon containers)
+	paths := []string{"/host-run/ostree-booted", "/run/ostree-booted"}
+
+	for _, path := range paths {
+		if _, err := fmd.fs.Stat(path); err == nil {
+			return true, nil // Image-based OS detected (file accessible)
+		} else if os.IsPermission(err) {
+			return true, nil // Image-based OS detected (file exists but permission denied)
+		} else if os.IsNotExist(err) {
+			// File doesn't exist, continue to next path
+			continue
+		} else {
+			return false, fmt.Errorf("Failed to check image-based OS status at %s: %v", path, err)
+		}
+	}
+
+	return false, nil // Not an image-based OS (file doesn't exist on any path)
+}
+
+// IsPackageMode checks if the OS uses traditional package-based deployment (rpm, deb, etc.)
+// Package mode is the inverse of image mode
+func (fmd *FilesystemModeDetector) IsPackageMode() (bool, error) {
+	isImageMode, err := fmd.IsImageMode()
+	if err != nil {
+		return false, err
+	}
+	// Package mode is the inverse of image mode
+	return !isImageMode, nil
+}

--- a/internal/utils/filesystem_mode_detector_test.go
+++ b/internal/utils/filesystem_mode_detector_test.go
@@ -1,0 +1,180 @@
+package utils_test
+
+import (
+	"github.com/openshift/dpu-operator/internal/utils"
+	"github.com/spf13/afero"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("FilesystemModeDetector", func() {
+	Describe("IsImageMode", func() {
+		Context("when /host-run/ostree-booted exists", func() {
+			It("should return true for image mode", func() {
+				hostRunIMFs := afero.NewMemMapFs()
+				hostRunIMFs.Create("/host-run/ostree-booted")
+
+				fmd := utils.NewFilesystemModeDetectorWithFs(hostRunIMFs)
+				imageMode, err := fmd.IsImageMode()
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(imageMode).To(BeTrue())
+			})
+		})
+
+		Context("when /run/ostree-booted exists", func() {
+			It("should return true for image mode", func() {
+				runIMFs := afero.NewMemMapFs()
+				runIMFs.Create("/run/ostree-booted")
+
+				fmd := utils.NewFilesystemModeDetectorWithFs(runIMFs)
+				imageMode, err := fmd.IsImageMode()
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(imageMode).To(BeTrue())
+			})
+		})
+
+		Context("when both paths exist", func() {
+			It("should return true for image mode (prioritizes /host-run)", func() {
+				bothPathsIMFs := afero.NewMemMapFs()
+				bothPathsIMFs.Create("/host-run/ostree-booted")
+				bothPathsIMFs.Create("/run/ostree-booted")
+
+				fmd := utils.NewFilesystemModeDetectorWithFs(bothPathsIMFs)
+				imageMode, err := fmd.IsImageMode()
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(imageMode).To(BeTrue())
+			})
+		})
+
+		Context("when only /host-run/ostree-booted exists", func() {
+			It("should return true for image mode", func() {
+				hostRunOnlyIMFs := afero.NewMemMapFs()
+				hostRunOnlyIMFs.Create("/host-run/ostree-booted")
+
+				fmd := utils.NewFilesystemModeDetectorWithFs(hostRunOnlyIMFs)
+				imageMode, err := fmd.IsImageMode()
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(imageMode).To(BeTrue())
+			})
+		})
+
+		Context("when only /run/ostree-booted exists", func() {
+			It("should return true for image mode", func() {
+				runOnlyIMFs := afero.NewMemMapFs()
+				runOnlyIMFs.Create("/run/ostree-booted")
+
+				fmd := utils.NewFilesystemModeDetectorWithFs(runOnlyIMFs)
+				imageMode, err := fmd.IsImageMode()
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(imageMode).To(BeTrue())
+			})
+		})
+
+		Context("when neither path exists", func() {
+			It("should return false for image mode", func() {
+				emptyFs := afero.NewMemMapFs()
+
+				fmd := utils.NewFilesystemModeDetectorWithFs(emptyFs)
+				imageMode, err := fmd.IsImageMode()
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(imageMode).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("IsPackageMode", func() {
+		Context("when system is in image mode", func() {
+			It("should return false for package mode", func() {
+				imageModeFs := afero.NewMemMapFs()
+				imageModeFs.Create("/host-run/ostree-booted")
+
+				fmd := utils.NewFilesystemModeDetectorWithFs(imageModeFs)
+				packageMode, err := fmd.IsPackageMode()
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(packageMode).To(BeFalse())
+			})
+		})
+
+		Context("when system is not in image mode", func() {
+			It("should return true for package mode", func() {
+				packageModeFs := afero.NewMemMapFs()
+
+				fmd := utils.NewFilesystemModeDetectorWithFs(packageModeFs)
+				packageMode, err := fmd.IsPackageMode()
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(packageMode).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("DetectMode", func() {
+		Context("when system is in image mode", func() {
+			It("should return ImageMode", func() {
+				imageModeFs := afero.NewMemMapFs()
+				imageModeFs.Create("/host-run/ostree-booted")
+
+				fmd := utils.NewFilesystemModeDetectorWithFs(imageModeFs)
+				mode, err := fmd.DetectMode()
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mode).To(Equal(utils.ImageMode))
+			})
+		})
+
+		Context("when system is in package mode", func() {
+			It("should return PackageMode", func() {
+				packageModeFs := afero.NewMemMapFs()
+
+				fmd := utils.NewFilesystemModeDetectorWithFs(packageModeFs)
+				mode, err := fmd.DetectMode()
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(mode).To(Equal(utils.PackageMode))
+			})
+		})
+	})
+
+	Describe("Integration tests", func() {
+		Context("when system has image mode characteristics", func() {
+			It("should detect image mode correctly and package mode as false", func() {
+				imageModeFs := afero.NewMemMapFs()
+				imageModeFs.Create("/run/ostree-booted")
+
+				fmd := utils.NewFilesystemModeDetectorWithFs(imageModeFs)
+
+				imageMode, err := fmd.IsImageMode()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(imageMode).To(BeTrue())
+
+				packageMode, err := fmd.IsPackageMode()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(packageMode).To(BeFalse())
+			})
+		})
+
+		Context("when system has package mode characteristics", func() {
+			It("should detect package mode correctly and image mode as false", func() {
+				packageModeFs := afero.NewMemMapFs()
+
+				fmd := utils.NewFilesystemModeDetectorWithFs(packageModeFs)
+
+				imageMode, err := fmd.IsImageMode()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(imageMode).To(BeFalse())
+
+				packageMode, err := fmd.IsPackageMode()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(packageMode).To(BeTrue())
+			})
+		})
+	})
+})

--- a/internal/utils/suite_test.go
+++ b/internal/utils/suite_test.go
@@ -1,0 +1,13 @@
+package utils_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}


### PR DESCRIPTION
The reason why we had the flavours as Openshift vs Microshift is that we assumed that if the DPU Operator is running on Openshift then it runs an immutable operating system, which in this case is CoreOS. Like wise if the operator is running on Microshift we assumed that the node is running classic RHEL (mutable). The assumptions are not wrong in our previous use cases but microshift's target audience seems to be for immutable flavors of RHEL, so we should make this more robust by checking whether a system is Classic RHEL or if its an OSTREE-Based RHEL, since it gives us a better way to know if parts of the filesystem is writeble or if binaries can even be installed on it by the Operator. This would also add compatibility with running Microshift on RHEL Image Mode, RHEL for edge or RHEL CoreOS on the DPU.

internal/utils/path_manager.go: Match each path to its respective flavour

OSTREE-Based immutable systems usually mount `/opt` as read only so we need it to use the path that the OpenShift flavour was using before. Likewise we let the ClassicRHEL flavour use the microshift path instead.

Mount /run so we can interact with ostree-booted

- Added a mountPath for `/run` and named it as host-run, so we have access to the `/run/ostree-booted` and check if it has been created or not. (Doing it this way lets us avoid any extra file creation that might give false positives for the `isOstree` function)

dpuoperatorconfig_controller.go: Change the controller to retrieve a set of Flavours instead of a single flavor

- Retrieving a set of flavours lets us match cases well such as being able to differentiate if something is microshift + RHEL For Edge or Openshift + Classic RHEL. (Basically able to match multiple flavours)