### PR TITLE
Intel ipu-opi-plugin upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-task/task/v3 v3.43.3
 	github.com/golang/glog v1.2.4
 	github.com/gorilla/mux v1.8.1
-	github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250722202314-5c941620a662
+	github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250804070152-0e29821c2d6a
 	github.com/jaypipes/ghw v0.13.1-0.20241024164530-c1bfc6e6cd6a
 	github.com/k8snetworkplumbingwg/cni-log v0.0.0-20230801160229-b6e062c9e0f2
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+h
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250722202314-5c941620a662 h1:3pnPxZWYGBSJfzOJAjcJRUqW6j5qxfrIxh+eROmAixo=
-github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250722202314-5c941620a662/go.mod h1:lzsjdWjRhMYe4nju1zWU8QL2MQG/jsAX6VMkD7iyCK4=
+github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250804070152-0e29821c2d6a h1:1wU22rFrM8cyr4zNPTRFpcmve+S/eEZ03jKJopmfFfI=
+github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250804070152-0e29821c2d6a/go.mod h1:lzsjdWjRhMYe4nju1zWU8QL2MQG/jsAX6VMkD7iyCK4=
 github.com/jaypipes/ghw v0.13.1-0.20241024164530-c1bfc6e6cd6a h1:orxBMCkYww7RFCk3iCDP9DC3l+yKtp4VdWtctCTyjPQ=
 github.com/jaypipes/ghw v0.13.1-0.20241024164530-c1bfc6e6cd6a/go.mod h1:F4UM7Ix55ONYwD3Lck2S4BI+hKezOwtizuJxXDFsioo=
 github.com/jaypipes/pcidb v1.0.1 h1:WB2zh27T3nwg8AE8ei81sNRb9yWBii3JGNJtT7K9Oic=

--- a/vendor/github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/firewall/firewall.go
+++ b/vendor/github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/firewall/firewall.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2025 Intel Corporation.  All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firewall
+
+import (
+	"bytes"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// portRule defines a set of ports under a zone and protocol.
+type portRule struct {
+	Zone  string
+	Proto string
+	Ports []string
+}
+
+// trustedCIDRs are the subnets granted full access in the internal zone.
+var trustedCIDRs = []string{
+	"169.254.169.0/24",
+	"192.168.0.0/24",
+}
+
+// portRules lists the ports opened per zone in configure mode.
+var portRules = []portRule{
+	{Zone: "internal", Proto: "tcp", Ports: []string{"9559"}},
+}
+
+// run executes a command and logs detailed errors on failure.
+func run(cmd string, args ...string) error {
+	full := append([]string{cmd}, args...)
+	log.Infof("executing command %s", strings.Join(full, " "))
+	c := exec.Command(cmd, args...)
+	var buf bytes.Buffer
+	c.Stdout, c.Stderr = &buf, &buf
+	if err := c.Run(); err != nil {
+		return fmt.Errorf("%s failed: %w\n%s", strings.Join(full, " "), err, buf.String())
+	}
+	return nil
+}
+
+// runSilent executes a command without logging output.
+func runSilent(cmd string, args ...string) error {
+	return exec.Command(cmd, args...).Run()
+}
+
+// ensureService starts and enables a systemd service if not already running.
+func ensureService(name string) error {
+	if err := runSilent("systemctl", "is-active", "--quiet", name); err != nil {
+		log.Infof("starting service %s", name)
+		if err := run("systemctl", "start", name); err != nil {
+			return fmt.Errorf("start %s: %w", name, err)
+		}
+	}
+	if err := runSilent("systemctl", "enable", name); err != nil {
+		return fmt.Errorf("enable %s: %w", name, err)
+	}
+	return nil
+}
+
+// applyRules adds or removes firewall rules based on mode ("configure" or "cleanup").
+func applyInternalRules(mode string) error {
+	// set default zone
+	zoneMap := map[string]string{"configure": "drop", "cleanup": "public"}
+	zone, ok := zoneMap[mode]
+	if !ok {
+		return fmt.Errorf("invalid mode %s", mode)
+	}
+	if err := run("firewall-cmd", "--set-default-zone="+zone); err != nil {
+		return fmt.Errorf("set default zone: %w", err)
+	}
+
+	// create or delete internal zone
+	if mode == "configure" {
+		_ = run("firewall-cmd", "--permanent", "--new-zone=internal")
+	} else {
+		_ = run("firewall-cmd", "--permanent", "--delete-zone=internal")
+	}
+
+	// prepare --permanent batch args
+	args := []string{"--permanent"}
+
+	// allow ingress (source) and egress (destination) for trusted CIDRs
+	for _, cidr := range trustedCIDRs {
+		// ingress rule via add/remove source
+		opSrc := "--add-source=" + cidr
+		// egress rule via rich rule
+		rule := fmt.Sprintf("rule family=\"ipv4\" destination address=\"%s\" accept", cidr)
+		opDst := fmt.Sprintf("--add-rich-rule=%s", rule)
+		// cleanup adjustments
+		if mode == "cleanup" {
+			opSrc = "--remove-source=" + cidr
+			// remove rich-rule syntax
+			rule = fmt.Sprintf("rule family=\"ipv4\" destination address=\"%s\" accept", cidr)
+			opDst = fmt.Sprintf("--remove-rich-rule=%s", rule)
+		}
+		args = append(args, "--zone=internal", opSrc, "--zone=internal", opDst)
+	}
+
+	// handle ports per rule
+	for _, rule := range portRules {
+		for _, p := range rule.Ports {
+			op := fmt.Sprintf("--add-port=%s/%s", p, rule.Proto)
+			if mode == "cleanup" {
+				op = fmt.Sprintf("--remove-port=%s/%s", p, rule.Proto)
+			}
+			args = append(args, fmt.Sprintf("--zone=%s", rule.Zone), op)
+		}
+	}
+
+	// execute single batch command
+	cmd := append([]string{"firewall-cmd"}, args...)
+	return run(cmd[0], cmd[1:]...)
+}
+
+// Configure applies a hardened firewall configuration and reloads.
+func Configure() error {
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("must run as root")
+	}
+	if _, err := exec.LookPath("firewall-cmd"); err != nil {
+		return fmt.Errorf("firewalld not installed: %w", err)
+	}
+
+	if err := ensureService("firewalld"); err != nil {
+		return err
+	}
+
+	if err := applyInternalRules("configure"); err != nil {
+		return err
+	}
+	if err := run("firewall-cmd", "--reload"); err != nil {
+		return fmt.Errorf("reload: %w", err)
+	}
+
+	log.Info("firewalld hardened successfully")
+	return nil
+}
+
+// CleanUp removes the hardened firewall configuration while preserving SSH connectivity.
+func CleanUp() error {
+	if err := ensureService("firewalld"); err != nil {
+		return err
+	}
+
+	if err := applyInternalRules("cleanup"); err != nil {
+		return err
+	}
+	if err := run("firewall-cmd", "--reload"); err != nil {
+		return fmt.Errorf("reload after cleanup: %w", err)
+	}
+
+	log.Info("firewalld cleanup complete")
+	return nil
+}
+

--- a/vendor/github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/ipuplugin/ipuplugin.go
+++ b/vendor/github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/ipuplugin/ipuplugin.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"syscall"
 	"time"
-
+        "github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/firewall"
 	"github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/infrapod"
 	"github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/p4rtclient"
 	"github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/types"
@@ -151,6 +151,10 @@ func (s *server) Run() error {
 	if err != nil {
 		return fmt.Errorf("unable to run IPU plugin")
 	}
+        // Configure ACC firewall settings to allow microshift, dpu-operator, ACC-IMC internal traffics.
+        if err := firewall.Configure(); err != nil {
+		log.Error(err, "firewall setup failed: %v", err)
+	}
 
 	if s.mode == types.IpuMode {
 		log.Info("Starting infrapod")
@@ -271,6 +275,11 @@ func (s *server) Stop() {
 		s.listener.Close()
 		_ = s.cleanUp()
 	}
+        //Reset firewall to its default settings.
+        if err := firewall.CleanUp(); err != nil {
+                log.Error(err, "firewall cleanup failed: %v", err)
+        }
+
 	s.log.Info("IPU plugin has stopped")
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -533,9 +533,10 @@ github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.1.0
 ## explicit; go 1.18
 github.com/inconshreveable/mousetrap
-# github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250722202314-5c941620a662
+# github.com/intel/ipu-opi-plugins/ipu-plugin v0.0.0-20250804070152-0e29821c2d6a
 ## explicit; go 1.23.6
 github.com/intel/ipu-opi-plugins/ipu-plugin/ipuplugin/cmd
+github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/firewall
 github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/infrapod
 github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/ipuplugin
 github.com/intel/ipu-opi-plugins/ipu-plugin/pkg/k8s/render


### PR DESCRIPTION
Enable firewalld at ACC with restricted access (#460)

Enable firewalld at ACC with restricted access to allow only all the internal and p4 communication

NOTE: This must go in with CDA changes which handles all the cluster specific port enabling at firewalld along with primary network access.