### PR TITLE
[th/rbac-watch-crd] give RBAC permission to watch CRD

### DIFF
--- a/bundle/manifests/dpu-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dpu-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-08-12T16:13:00Z"
+    createdAt: "2025-08-12T16:14:09Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
     features.operators.openshift.io/csi: "false"
@@ -167,6 +167,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - apps
           resources:

--- a/bundle/manifests/dpu-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dpu-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-07-09T11:00:12Z"
+    createdAt: "2025-08-12T16:13:00Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
     features.operators.openshift.io/csi: "false"
@@ -403,6 +403,9 @@ spec:
                 - mountPath: /tmp/k8s-webhook-server/serving-certs
                   name: cert
                   readOnly: true
+                - mountPath: /host-run
+                  name: host-run
+                  readOnly: true
               securityContext:
                 runAsNonRoot: true
                 seccompProfile:
@@ -414,6 +417,10 @@ spec:
                 secret:
                   defaultMode: 420
                   secretName: webhook-server-cert
+              - hostPath:
+                  path: /run
+                  type: DirectoryOrCreate
+                name: host-run
       permissions:
       - rules:
         - apiGroups:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -92,6 +92,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/internal/controller/bindata/daemon/04.daemon_cluster_role.yaml
+++ b/internal/controller/bindata/daemon/04.daemon_cluster_role.yaml
@@ -9,6 +9,8 @@ rules:
   - customresourcedefinitions
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/controller/dpuoperatorconfig_controller.go
+++ b/internal/controller/dpuoperatorconfig_controller.go
@@ -76,7 +76,7 @@ func (r *DpuOperatorConfigReconciler) WithImagePullPolicy(policy string) *DpuOpe
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;delete;patch
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=list;get
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,verbs=*

--- a/manifests/stable/dpu-operator.clusterserviceversion.yaml
+++ b/manifests/stable/dpu-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-08-12T16:13:00Z"
+    createdAt: "2025-08-12T16:14:09Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
     features.operators.openshift.io/csi: "false"
@@ -167,6 +167,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - apps
           resources:

--- a/manifests/stable/dpu-operator.clusterserviceversion.yaml
+++ b/manifests/stable/dpu-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-07-09T11:00:12Z"
+    createdAt: "2025-08-12T16:13:00Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "true"
     features.operators.openshift.io/csi: "false"
@@ -403,6 +403,9 @@ spec:
                 - mountPath: /tmp/k8s-webhook-server/serving-certs
                   name: cert
                   readOnly: true
+                - mountPath: /host-run
+                  name: host-run
+                  readOnly: true
               securityContext:
                 runAsNonRoot: true
                 seccompProfile:
@@ -414,6 +417,10 @@ spec:
                 secret:
                   defaultMode: 420
                   secretName: webhook-server-cert
+              - hostPath:
+                  path: /run
+                  type: DirectoryOrCreate
+                name: host-run
       permissions:
       - rules:
         - apiGroups:


### PR DESCRIPTION
`oc logs pod/dpu-operator-controller-manager-6f6cdb4f8f-m58g9` is full of

    E0812 16:15:22.598795       1 reflector.go:166] "Unhandled Error" err="sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:108: Failed to watch *v1.CustomResourceDefinition: customresourcedefinitions.apiextensions.k8s.io is forbidden: User \"system:serviceaccount:openshift-dpu-operator:dpu-operator-controller-manager\" cannot watch resource \"customresourcedefinitions\" in API group \"apiextensions.k8s.io\" at the cluster scope" logger="UnhandledError"