### PR TITLE
OCPBUGS-60658: [th/priviledged-sfc] Make the SFC container to be in privileged mode

### DIFF
--- a/examples/my-pod.yaml
+++ b/examples/my-pod.yaml
@@ -14,7 +14,7 @@ spec:
     command: ['/bin/sh', '-c', 'sleep infinity']
     imagePullPolicy: Always
     securityContext:
-      priviledged: true
+      privileged: true
       runAsNonRoot: false
       runAsUser: 0
       seccompProfile:

--- a/internal/daemon/sfc-reconciler/sfc.go
+++ b/internal/daemon/sfc-reconciler/sfc.go
@@ -30,7 +30,7 @@ type SfcReconciler struct {
 }
 
 func networkFunctionPod(name string, image string) *corev1.Pod {
-	falseVar := false
+	trueVar := true
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -59,7 +59,7 @@ func networkFunctionPod(name string, image string) *corev1.Pod {
 						},
 					},
 					SecurityContext: &corev1.SecurityContext{
-						AllowPrivilegeEscalation: &falseVar,
+						Privileged: &trueVar,
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{"ALL"},
 							Add:  []corev1.Capability{"NET_RAW", "NET_ADMIN"},


### PR DESCRIPTION
* Grant privileged access to SFC container
* Remove AllowPrivilegeEscalation since privileged automatically makes it true
* Correct typo in my-pod.yaml for privileged

Signed-off-by: Sayan Bandyopadhyay <sayan.bandyopadhyay@intel.com>
(cherry picked from commit 13b0558d64934eeabbf7488ce937376147adb4ca)

Without this, we don't have permissions to run the default "nginx" container. While we may revise this in the future, this is what we currently do on main branch. Backport.