### PR TITLE
Remove Mode field and Add support for Layer 3 Network Functions on PTL

### DIFF
--- a/api/v1/dpuoperatorconfig_types.go
+++ b/api/v1/dpuoperatorconfig_types.go
@@ -27,10 +27,6 @@ import (
 
 // DpuOperatorConfigSpec defines the desired state of DpuOperatorConfig
 type DpuOperatorConfigSpec struct {
-	// Mode can be "host" or "dpu" and it defines on which side we are
-	// TODO: add support for auto
-	Mode string `json:"mode,omitempty"`
-
 	// Set log level of the operator. Edit dpuoperatorconfig_types.go to remove/update
 	LogLevel int `json:"logLevel,omitempty"`
 }

--- a/api/v1/dpuoperatorconfig_webhook.go
+++ b/api/v1/dpuoperatorconfig_webhook.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"context"
 	"fmt"
+
 	"github.com/openshift/dpu-operator/pkgs/vars"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -50,11 +51,6 @@ var _ webhook.CustomValidator = &DpuOperatorConfig{}
 func (r *DpuOperatorConfig) validateDpuOperatorConfig() (admission.Warnings, error) {
 	if r.Name != vars.DpuOperatorConfigName {
 		return nil, fmt.Errorf("DpuOperatorConfig must have standard name \"%s\"", vars.DpuOperatorConfigName)
-	}
-
-	mode := r.Spec.Mode
-	if mode != "host" && mode != "dpu" && mode != "auto" {
-		return nil, fmt.Errorf("Invalid mode")
 	}
 
 	return nil, nil

--- a/api/v1/dpuoperatorconfig_webhook_test.go
+++ b/api/v1/dpuoperatorconfig_webhook_test.go
@@ -32,7 +32,6 @@ var _ = Describe("Webhook Unit Test", func() {
 			config := &DpuOperatorConfig{}
 			config.SetName(vars.DpuOperatorConfigName)
 			config.Spec = DpuOperatorConfigSpec{
-				Mode:     "host",
 				LogLevel: 2,
 			}
 
@@ -64,7 +63,7 @@ var _ = Describe("Webhook Test", func() {
 					Namespace: vars.Namespace,
 				},
 				Spec: DpuOperatorConfigSpec{
-					Mode: "host",
+					LogLevel: 0,
 				},
 			}
 			err = k8sClient.Create(ctx, createValid)
@@ -85,25 +84,13 @@ var _ = Describe("Webhook Test", func() {
 		It("should reject invalid DpuOperatorConfig", func() {
 			var err error
 
-			createInvalidMode := &DpuOperatorConfig{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      vars.DpuOperatorConfigName,
-					Namespace: vars.Namespace,
-				},
-				Spec: DpuOperatorConfigSpec{
-					Mode: "invalid",
-				},
-			}
-			err = k8sClient.Create(ctx, createInvalidMode)
-			Expect(err).To(HaveOccurred())
-
 			createInvalidName := &DpuOperatorConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "invalid",
 					Namespace: vars.Namespace,
 				},
 				Spec: DpuOperatorConfigSpec{
-					Mode: "host",
+					LogLevel: 0,
 				},
 			}
 			err = k8sClient.Create(ctx, createInvalidName)

--- a/config/crd/bases/config.openshift.io_dpuoperatorconfigs.yaml
+++ b/config/crd/bases/config.openshift.io_dpuoperatorconfigs.yaml
@@ -43,11 +43,6 @@ spec:
                 description: Set log level of the operator. Edit dpuoperatorconfig_types.go
                   to remove/update
                 type: integer
-              mode:
-                description: |-
-                  Mode can be "host" or "dpu" and it defines on which side we are
-                  TODO: add support for auto
-                type: string
             type: object
           status:
             description: DpuOperatorConfigStatus defines the observed state of DpuOperatorConfig

--- a/config/samples/config_v1_dpuoperatorconfig.yaml
+++ b/config/samples/config_v1_dpuoperatorconfig.yaml
@@ -9,4 +9,4 @@ metadata:
     app.kubernetes.io/created-by: dpu-operator
   name: dpuoperatorconfig-sample
 spec:
-  mode: host
+  logLevel: 0

--- a/examples/dpu.yaml
+++ b/examples/dpu.yaml
@@ -3,4 +3,4 @@ kind: DpuOperatorConfig
 metadata:
   name: dpu-operator-config
 spec:
-  mode: dpu
+  logLevel: 0

--- a/examples/host.yaml
+++ b/examples/host.yaml
@@ -3,4 +3,4 @@ kind: DpuOperatorConfig
 metadata:
   name: dpu-operator-config
 spec:
-  mode: host
+  logLevel: 0

--- a/examples/my-pod-2.yaml
+++ b/examples/my-pod-2.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: my-pod
+  name: my-pod-2
   namespace: default
   annotations:
     k8s.v1.cni.cncf.io/networks: default-sriov-net

--- a/internal/controller/dpuoperatorconfig_controller.go
+++ b/internal/controller/dpuoperatorconfig_controller.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"embed"
-	"fmt"
 
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/dpu-operator/api/v1"
@@ -188,19 +187,25 @@ func (r *DpuOperatorConfigReconciler) ensureNetworkResourcesInjector(ctx context
 }
 func (r *DpuOperatorConfigReconciler) ensureNetworkFunctioNAD(ctx context.Context, cfg *configv1.DpuOperatorConfig) error {
 	logger := log.FromContext(ctx)
-	logger.Info("Create the Network Function NAD")
-	nadFile := ""
-	switch cfg.Spec.Mode {
-	case "dpu":
-		nadFile = "networkfn-nad-dpu"
-	case "host":
-		nadFile = "networkfn-nad-host"
-	default:
-		err := errors.NewBadRequest(fmt.Sprintf("Invalid Mode: %s", cfg.Spec.Mode))
-		logger.Error(err, "Invalid mode specified")
+
+	// Both Host and DPU NADs are created here even though this operator can run exclusively on
+	// either Host or DPU. The pod definition must choose the correct NAD for the node that the
+	// pod will be running on (dpu would be networkfn-nad-dpu and host would be networkfn-nad-host).
+	logger.Info("Create the Network Function DPU NAD")
+	err := r.createAndApplyAllFromBinData(logger, "networkfn-nad-dpu", cfg)
+	if err != nil {
+		logger.Error(err, "Failed to create Network Function DPU NAD")
 		return err
 	}
-	return r.createAndApplyAllFromBinData(logger, nadFile, cfg)
+
+	logger.Info("Create the Network Function Host NAD")
+	err = r.createAndApplyAllFromBinData(logger, "networkfn-nad-host", cfg)
+	if err != nil {
+		logger.Error(err, "Failed to create Network Function Host NAD")
+		return err
+	}
+
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/dpuoperatorconfig_controller_test.go
+++ b/internal/controller/dpuoperatorconfig_controller_test.go
@@ -129,10 +129,10 @@ var _ = Describe("Main Controller", Ordered, func() {
 		Context("When DpuOperatorConfig CR exists with host mode", func() {
 			BeforeAll(func() {
 				ns := testutils.DpuOperatorNamespace()
-				cr = testutils.DpuOperatorCR(testDpuOperatorConfigName, "host", ns)
+				cr = testutils.DpuOperatorCR(testDpuOperatorConfigName, ns)
 
 				// Ensure any existing CR is cleaned up first
-				existingCr := testutils.DpuOperatorCR(testDpuOperatorConfigName, "host", ns)
+				existingCr := testutils.DpuOperatorCR(testDpuOperatorConfigName, ns)
 				testutils.DeleteDpuOperatorCR(mgr.GetClient(), existingCr)
 
 				testutils.CreateNamespace(mgr.GetClient(), ns)
@@ -151,7 +151,7 @@ var _ = Describe("Main Controller", Ordered, func() {
 			})
 			AfterAll(func() {
 				ns := testutils.DpuOperatorNamespace()
-				cr = testutils.DpuOperatorCR(testDpuOperatorConfigName, "host", ns)
+				cr = testutils.DpuOperatorCR(testDpuOperatorConfigName, ns)
 				testutils.DeleteDpuOperatorCR(mgr.GetClient(), cr)
 			})
 		})
@@ -159,10 +159,10 @@ var _ = Describe("Main Controller", Ordered, func() {
 		Context("When DpuOperatorConfig CR is created with dpu mode", func() {
 			BeforeAll(func() {
 				ns := testutils.DpuOperatorNamespace()
-				cr = testutils.DpuOperatorCR("operator-config", "dpu", ns)
+				cr = testutils.DpuOperatorCR("operator-config", ns)
 
 				// Ensure any existing CR is cleaned up first
-				existingCr := testutils.DpuOperatorCR("operator-config", "dpu", ns)
+				existingCr := testutils.DpuOperatorCR("operator-config", ns)
 				testutils.DeleteDpuOperatorCR(mgr.GetClient(), existingCr)
 
 				testutils.CreateNamespace(mgr.GetClient(), ns)
@@ -183,7 +183,7 @@ var _ = Describe("Main Controller", Ordered, func() {
 			})
 			AfterAll(func() {
 				ns := testutils.DpuOperatorNamespace()
-				cr = testutils.DpuOperatorCR("operator-config", "host", ns)
+				cr = testutils.DpuOperatorCR("operator-config", ns)
 				testutils.DeleteDpuOperatorCR(mgr.GetClient(), cr)
 			})
 		})

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -68,10 +68,10 @@ var _ = g.Describe("Full Daemon", func() {
 		k8sClient, err = client.New(config, client.Options{Scheme: scheme.Scheme})
 		Expect(err).NotTo(HaveOccurred())
 		ns := testutils.DpuOperatorNamespace()
-		cr := testutils.DpuOperatorCR("dpu-operator-config", "host", ns)
+		cr := testutils.DpuOperatorCR("dpu-operator-config", ns)
 
 		// Clean up any existing resources first
-		existingCr := testutils.DpuOperatorCR("dpu-operator-config", "host", ns)
+		existingCr := testutils.DpuOperatorCR("dpu-operator-config", ns)
 		testutils.DeleteDpuOperatorCR(k8sClient, existingCr)
 
 		testutils.CreateNamespace(k8sClient, ns)
@@ -85,10 +85,10 @@ var _ = g.Describe("Full Daemon", func() {
 		k8sClient, err := client.New(config, client.Options{})
 		Expect(err).NotTo(HaveOccurred())
 		namespace := testutils.DpuOperatorNamespace()
-		dpuOperatorConfig := testutils.DpuOperatorCR(vars.DpuOperatorConfigName, "auto", namespace)
+		dpuOperatorConfig := testutils.DpuOperatorCR(vars.DpuOperatorConfigName, namespace)
 
 		// Clean up any existing resources first
-		existingDpuOperatorConfig := testutils.DpuOperatorCR(vars.DpuOperatorConfigName, "auto", namespace)
+		existingDpuOperatorConfig := testutils.DpuOperatorCR(vars.DpuOperatorConfigName, namespace)
 		testutils.DeleteDpuOperatorCR(k8sClient, existingDpuOperatorConfig)
 
 		testutils.CreateNamespace(k8sClient, namespace)
@@ -157,12 +157,12 @@ var _ = g.Describe("Full Daemon", func() {
 		}
 		klog.Info("Clean up DpuOperatorConfig resources")
 		namespace := testutils.DpuOperatorNamespace()
-		dpuOperatorConfig := testutils.DpuOperatorCR(vars.DpuOperatorConfigName, "auto", namespace)
+		dpuOperatorConfig := testutils.DpuOperatorCR(vars.DpuOperatorConfigName, namespace)
 		klog.Infof("Deleting DpuOperatorConfig: %s", vars.DpuOperatorConfigName)
 		testutils.DeleteDpuOperatorCR(k8sClient, dpuOperatorConfig)
 
 		// Also clean up the original CR
-		cr := testutils.DpuOperatorCR("dpu-operator-config", "host", namespace)
+		cr := testutils.DpuOperatorCR("dpu-operator-config", namespace)
 		klog.Info("Deleting original CR: dpu-operator-config")
 		testutils.DeleteDpuOperatorCR(k8sClient, cr)
 		klog.Infof("Deleting namespace: %s", namespace.Name)

--- a/internal/daemon/vendor-specific-plugins/common/vspnetutils.go
+++ b/internal/daemon/vendor-specific-plugins/common/vspnetutils.go
@@ -20,10 +20,14 @@ const (
 	netDevVfDevicePrefix = "virtfn"
 )
 
+type VethPairKey struct {
+	IfMac string // MAC address of the veth interface
+}
+
 type VEthPairDeviceInfo struct {
+	VethKey   VethPairKey
 	IfName    string // Interface Name of the veth
 	PeerName  string // Interface Name of the peer veth
-	IfMac     string // MAC address of the veth interface
 	PeerIfMAC string // MAC address of the Peer veth interface
 }
 
@@ -131,9 +135,9 @@ func CreateNfVethPair(idx int) (*VEthPairDeviceInfo, error) {
 // CreateVethPair function to create a veth pair with the given index and InterfaceInfo
 func CreateVethPair(ifname string, peername string) (*VEthPairDeviceInfo, error) {
 	deviceInfo := VEthPairDeviceInfo{
+		VethKey:   VethPairKey{IfMac: ""},
 		IfName:    ifname,
 		PeerName:  peername,
-		IfMac:     "",
 		PeerIfMAC: "",
 	}
 
@@ -182,7 +186,7 @@ func CreateVethPair(ifname string, peername string) (*VEthPairDeviceInfo, error)
 		return nil, err
 	}
 
-	deviceInfo.IfMac = ifLink.Attrs().HardwareAddr.String()
+	deviceInfo.VethKey.IfMac = ifLink.Attrs().HardwareAddr.String()
 	deviceInfo.PeerIfMAC = peerLink.Attrs().HardwareAddr.String()
 
 	return &deviceInfo, nil
@@ -241,23 +245,27 @@ func SetPfHwModeVepa(pfName string) error {
 // TODO: Use https://github.com/ovn-kubernetes/libovsdb/tree/main
 func CreateOvSBridge(bridgeName string) error {
 	cmd := exec.Command("chroot", "/host", "ovs-vsctl", "--may-exist", "add-br", bridgeName)
+	klog.Infof("CreateOvSBridge(): %s", cmd.String())
 	return cmd.Run()
 }
 
 // TODO: Use https://github.com/ovn-kubernetes/libovsdb/tree/main
 func DeleteOvSBridge(bridgeName string) error {
 	cmd := exec.Command("chroot", "/host", "ovs-vsctl", "del-br", bridgeName)
+	klog.Infof("DeleteOvSBridge(): %s", cmd.String())
 	return cmd.Run()
 }
 
 // TODO: Use https://github.com/ovn-kubernetes/libovsdb/tree/main
 func AddInterfaceToOvSBridge(bridgeName string, ifname string) error {
 	cmd := exec.Command("chroot", "/host", "ovs-vsctl", "--may-exist", "add-port", bridgeName, ifname)
+	klog.Infof("AddInterfaceToOvSBridge(): %s", cmd.String())
 	return cmd.Run()
 }
 
 // TODO: Use https://github.com/ovn-kubernetes/libovsdb/tree/main
 func DeleteInterfaceFromOvSBridge(bridgeName string, ifname string) error {
 	cmd := exec.Command("chroot", "/host", "ovs-vsctl", "del-port", bridgeName, ifname)
+	klog.Infof("DeleteInterfaceFromOvSBridge(): %s", cmd.String())
 	return cmd.Run()
 }

--- a/internal/daemon/vendor-specific-plugins/intel-netsec/main.go
+++ b/internal/daemon/vendor-specific-plugins/intel-netsec/main.go
@@ -40,6 +40,7 @@ const (
 	IntelNetSecDpuBackplanef3PCIeAddress string = "0000:f4:00.3"
 	VlanOffset                           int    = 2 // Vlan ID offset since vlan 0 is untagged and to reserve vlan 1
 	NoOfVethPairs                        int    = 2 // Only support 1 Network Function with 2 pairs (TODO: Need CRD)
+	MaxChains                            int    = 1 // Only support 1 Chain of Network Functions
 	OvSBridgeName                        string = "br-secondary"
 )
 
@@ -63,8 +64,22 @@ type intelNetSecVspServer struct {
 	dpuPcieAddress string               // PCIe address of the DPU device (function 0) on the Host
 	// Intel NetSec Accelerator specific interfaces
 	vfCnt              int
-	vethTunnelPairDevs []*vspnetutils.VEthPairDeviceInfo
+	vethTunnelPairDevs map[vspnetutils.VethPairKey]*vspnetutils.VEthPairDeviceInfo
 	vfDevs             map[vspnetutils.VfDeviceKey]*vspnetutils.VfDeviceInfo
+	// Network Functions
+	numNfs                int
+	serviceFunctionChains map[int]*intelNetSecServiceFunctionChain
+}
+
+// This datastructure represents a pseudo VF representor. Representor lanes are created with layer2 VLAN isolation.
+type intelNetSecVfRepDev struct {
+	vfRepDev    *vspnetutils.VfDeviceInfo
+	hostSideMac string
+}
+
+type intelNetSecServiceFunctionChain struct {
+	vfRepDevs map[vspnetutils.VfDeviceKey]*intelNetSecVfRepDev
+	sfpVfDevs *vspnetutils.VfDeviceInfo
 }
 
 // getVFs retrieves the VF PCIe addresses for the given PF PCIe address for Intel NetSec accelerator devices.
@@ -105,7 +120,7 @@ func (vsp *intelNetSecVspServer) configureCommChannelIPs(dpuMode bool) (pb.IpPor
 		}
 
 		if len(ifNames) != 1 {
-			err = fmt.Errorf("expected exactly 1 interface for PCIe address %s, got %d", IntelNetSecDpuBackplanef2PCIeAddress, len(ifNames))
+			err = fmt.Errorf("expected exactly 1 interface for PCIe address %s, got %v", IntelNetSecDpuBackplanef2PCIeAddress, ifNames)
 			vsp.log.Error(err, "Error getting netdev name from PCIe address in DPU mode", "PCIeAddress", IntelNetSecDpuBackplanef2PCIeAddress)
 			return pb.IpPort{}, err
 		}
@@ -120,7 +135,7 @@ func (vsp *intelNetSecVspServer) configureCommChannelIPs(dpuMode bool) (pb.IpPor
 		}
 
 		if len(ifNames) != 1 {
-			err = fmt.Errorf("expected exactly 1 interface for PCIe address %s, got %d", vsp.dpuPcieAddress, len(ifNames))
+			err = fmt.Errorf("expected exactly 1 interface for PCIe address %s, got %v", vsp.dpuPcieAddress, ifNames)
 			vsp.log.Error(err, "Error getting netdev name from PCIe address in Host mode", "PCIeAddress", vsp.dpuPcieAddress)
 			return pb.IpPort{}, err
 		}
@@ -207,10 +222,62 @@ func (vsp *intelNetSecVspServer) initOvSDataPlane(bridgeName string) error {
 	}
 
 	if len(sfpPortIfNames) != 1 {
-		return fmt.Errorf("expected exactly 1 interface for PCIe address %s, got %d", IntelNetSecDpuSFPf1PCIeAddress, len(sfpPortIfNames))
+		return fmt.Errorf("expected exactly 1 interface for PCIe address %s, got %v", IntelNetSecDpuSFPf1PCIeAddress, sfpPortIfNames)
 	}
 
-	err = vspnetutils.AddInterfaceToOvSBridge(bridgeName, sfpPortIfNames[0])
+	sfpPortIfName := sfpPortIfNames[0]
+
+	// The following code takes the second SFP port's first VF and adds this VF to the OvS bridge.
+	// The reason why a VF is chosen is to support VLAN use cases and multiple independent chains.
+	// TODO: When more chains are supported we need to put the following in a loop
+	vfPcieAddr, err := vspnetutils.VfPCIAddressFromVfIndex(vsp.fs, sfpPortIfName, 0)
+	if err != nil {
+		vsp.log.Error(err, "Error getting VF PCI address", "VFID", 0, "InterfaceName", sfpPortIfName)
+		return err
+	}
+
+	vfIfNames, err := vsp.platform.GetNetDevNameFromPCIeAddr(vfPcieAddr)
+	if err != nil {
+		vsp.log.Error(err, "Error occurred in getting SFP Port Interface Name", "PCIeAddress", IntelNetSecDpuSFPf1PCIeAddress)
+		return err
+	}
+
+	if len(vfIfNames) != 1 {
+		return fmt.Errorf("expected exactly 1 interface for PCIe address %s, got %v", vfPcieAddr, vfIfNames)
+	}
+
+	vfIfName := vfIfNames[0]
+
+	sfpPortlink, err := netlink.LinkByName(sfpPortIfName)
+	if err != nil {
+		vsp.log.Error(err, "Failed to get link by name", "sfpPortIfName", sfpPortIfName)
+		return err
+	}
+
+	if err := netlink.LinkSetVfSpoofchk(sfpPortlink, 0, false); err != nil {
+		vsp.log.Error(err, "Failed to set spoof check off for VF", "VfID", 0, "sfpPortIfName", sfpPortIfName)
+		return err
+	}
+
+	if err := netlink.LinkSetVfTrust(sfpPortlink, 0, true); err != nil {
+		vsp.log.Error(err, "Failed to set trust on for VF", "VfID", 0, "sfpPortIfName", sfpPortIfName)
+		return err
+	}
+
+	vsp.serviceFunctionChains[0] = &intelNetSecServiceFunctionChain{
+		sfpVfDevs: &vspnetutils.VfDeviceInfo{
+			VfKey: vspnetutils.VfDeviceKey{
+				PfInterfaceName: sfpPortIfName,
+				Id:              0,
+			},
+			PciAddress: vfPcieAddr,
+			Vlan:       0,
+			Allocated:  true,
+		},
+		vfRepDevs: make(map[vspnetutils.VfDeviceKey]*intelNetSecVfRepDev),
+	}
+
+	err = vspnetutils.AddInterfaceToOvSBridge(bridgeName, vfIfName)
 	if err != nil {
 		vsp.log.Error(err, "Error occurred in adding SFP Port Interface to Bridge", "BridgeName", bridgeName, "SfpPortIfName", sfpPortIfNames[0])
 		return err
@@ -228,7 +295,7 @@ func (vsp *intelNetSecVspServer) createVethPairs() error {
 			vsp.log.Error(err, "Error creating veth pair", "Index", idx)
 			return err
 		}
-		vsp.vethTunnelPairDevs = append(vsp.vethTunnelPairDevs, pair)
+		vsp.vethTunnelPairDevs[pair.VethKey] = pair
 	}
 
 	vsp.log.Info("createVethPairs(): Created veth pairs", "Count", len(vsp.vethTunnelPairDevs))
@@ -349,7 +416,7 @@ func (vsp *intelNetSecVspServer) getConnectedVf(OPIBridgePortName string) (*vspn
 	}
 
 	if len(pfIfNames) != 1 {
-		err = fmt.Errorf("expected exactly 1 interface for PCIe address %s, got %d", backPlanePcieAddr, len(pfIfNames))
+		err = fmt.Errorf("expected exactly 1 interface for PCIe address %s, got %v", backPlanePcieAddr, pfIfNames)
 		vsp.log.Error(err, "Error getting netdev name from PCIe address", "PCIeAddress", backPlanePcieAddr)
 		return nil, err
 	}
@@ -381,6 +448,12 @@ func (vsp *intelNetSecVspServer) CreateBridgePort(ctx context.Context, in *opi.C
 		return nil, err
 	}
 
+	if vfDevice.Allocated == true {
+		err = fmt.Errorf("VF Device is already allocated PFInterfaceName: %s, VFId: %d", vfDevice.VfKey.PfInterfaceName, vfDevice.VfKey.Id)
+		vsp.log.Error(err, "CreateBridgePort() VF Device is already allocated")
+		return nil, err
+	}
+
 	vfIfNames, err := vsp.platform.GetNetDevNameFromPCIeAddr(vfDevice.PciAddress)
 	if err != nil {
 		vsp.log.Error(err, "Error getting netdev name from PCIe address", "PCIeAddress", vfDevice.PciAddress)
@@ -388,7 +461,7 @@ func (vsp *intelNetSecVspServer) CreateBridgePort(ctx context.Context, in *opi.C
 	}
 
 	if len(vfIfNames) != 1 {
-		err = fmt.Errorf("expected exactly 1 interface for PCIe address %s, got %d", vfDevice.PciAddress, len(vfIfNames))
+		err = fmt.Errorf("expected exactly 1 interface for PCIe address %s, got %v", vfDevice.PciAddress, vfIfNames)
 		vsp.log.Error(err, "Error getting netdev name from PCIe address", "PCIeAddress", vfDevice.PciAddress)
 		return nil, err
 	}
@@ -399,6 +472,21 @@ func (vsp *intelNetSecVspServer) CreateBridgePort(ctx context.Context, in *opi.C
 	if err != nil {
 		vsp.log.Error(err, "Error adding VF to OvS Bridge", "BridgePortName", in.BridgePort.Name, "vfIfName", vfIfName)
 		return nil, err
+	}
+
+	macStr := net.HardwareAddr(in.BridgePort.Spec.MacAddress).String()
+	_, exists := vsp.serviceFunctionChains[0].vfRepDevs[vfDevice.VfKey]
+	if exists {
+		err = fmt.Errorf("VF Device is already exists PFInterfaceName: %s, VFId: %d", vfDevice.VfKey.PfInterfaceName, vfDevice.VfKey.Id)
+		vsp.log.Error(err, "CreateBridgePort() VF Device is already exists")
+		return nil, err
+	} else {
+		vsp.serviceFunctionChains[0].vfRepDevs[vfDevice.VfKey] = &intelNetSecVfRepDev{
+			vfRepDev:    vfDevice,
+			hostSideMac: macStr,
+		}
+		vfDevice.Allocated = true
+		vsp.log.Info("CreateBridgePort(): Added VF to Service Function Chain", "BridgePortName", in.BridgePort.Name, "vfIfName", vfIfName, "vfDevice", vfDevice, "hostSideMac", macStr)
 	}
 
 	vsp.log.Info("CreateBridgePort(): Added VF to OvS Bridge", "BridgePortName", in.BridgePort.Name, "vfIfName", vfIfName)
@@ -422,7 +510,7 @@ func (vsp *intelNetSecVspServer) DeleteBridgePort(ctx context.Context, in *opi.D
 	}
 
 	if len(vfIfNames) != 1 {
-		err = fmt.Errorf("expected exactly 1 interface for PCIe address %s, got %d", vfDevice.PciAddress, len(vfIfNames))
+		err = fmt.Errorf("expected exactly 1 interface for PCIe address %s, got %v", vfDevice.PciAddress, vfIfNames)
 		vsp.log.Error(err, "Error getting netdev name from PCIe address", "PCIeAddress", vfDevice.PciAddress)
 		return nil, err
 	}
@@ -435,20 +523,127 @@ func (vsp *intelNetSecVspServer) DeleteBridgePort(ctx context.Context, in *opi.D
 		return nil, err
 	}
 
+	vfDeviceFromSFC, ok := vsp.serviceFunctionChains[0].vfRepDevs[vfDevice.VfKey]
+	if !ok {
+		err = fmt.Errorf("VF Device not found PFInterfaceName: %s, VFId: %d", vfDevice.VfKey.PfInterfaceName, vfDevice.VfKey.Id)
+		vsp.log.Error(err, "DeleteBridgePort() could not find VF Device")
+		return nil, err
+	}
+
+	if vfDeviceFromSFC.vfRepDev.Allocated == false {
+		err = fmt.Errorf("VF Device is not allocated PFInterfaceName: %s, VFId: %d", vfDevice.VfKey.PfInterfaceName, vfDevice.VfKey.Id)
+		vsp.log.Error(err, "DeleteBridgePort() VF Device is not allocated")
+		return nil, err
+	}
+
+	vfDeviceFromSFC.vfRepDev.Allocated = false
+	delete(vsp.serviceFunctionChains[0].vfRepDevs, vfDevice.VfKey)
+
 	vsp.log.Info("DeleteBridgePort(): Deleted VF from OvS Bridge", "BridgePortName", in.Name, "vfIfName", vfIfName)
 
 	return nil, nil
 }
 
+func (vsp *intelNetSecVspServer) vethUpAndAddToBridge(veth *vspnetutils.VEthPairDeviceInfo) error {
+	// The peer interface is the dataplane interface that needs to be up and added to the bridge.
+	vethLink, err := netlink.LinkByName(veth.PeerName)
+	if err != nil {
+		vsp.log.Error(err, "Error getting inport Veth", "InportVeth", veth.IfName, "PeerName", veth.PeerName)
+		return err
+	}
+
+	vsp.log.Info("vethUpAndAddToBridge(): Setting up dataplane interface", "PeerName", veth.PeerName)
+	if err := netlink.LinkSetUp(vethLink); err != nil {
+		vsp.log.Error(err, "Error setting up inport Veth", "InportVeth", veth.IfName, "PeerName", veth.PeerName)
+		return err
+	}
+
+	vsp.log.Info("vethUpAndAddToBridge(): Adding dataplane interface to OvS Bridge", "PeerName", veth.PeerName)
+	err = vspnetutils.AddInterfaceToOvSBridge(OvSBridgeName, veth.PeerName)
+	if err != nil {
+		vsp.log.Error(err, "Error adding inport Veth to OvS Bridge", "InportVeth", veth.IfName, "PeerName", veth.PeerName)
+		return err
+	}
+
+	return nil
+}
+
 // TODO: Implement this
 func (vsp *intelNetSecVspServer) CreateNetworkFunction(ctx context.Context, in *pb.NFRequest) (*pb.Empty, error) {
 	vsp.log.Info("Received CreateNetworkFunction() request", "Input", in.Input, "Output", in.Output)
-	return nil, nil
+
+	// The expectation is that 2 devices would be allocated for the Network Function and we use the mac addresses
+	// of each VETH pair to find it and add them to the bridge.
+	inportVeth, ok := vsp.vethTunnelPairDevs[vspnetutils.VethPairKey{IfMac: in.Input}]
+	if !ok {
+		err := fmt.Errorf("veth pair not found for input: %s", in.Input)
+		vsp.log.Error(err, "Error getting inport Veth", "InportVeth", in.Input)
+		return nil, err
+	}
+	vsp.log.Info("CreateNetworkFunction(): Inport Veth", "InportVeth", inportVeth)
+
+	outportVeth, ok := vsp.vethTunnelPairDevs[vspnetutils.VethPairKey{IfMac: in.Output}]
+	if !ok {
+		err := fmt.Errorf("veth pair not found for output: %s", in.Output)
+		vsp.log.Error(err, "Error getting outport Veth", "OutportVeth", in.Output)
+		return nil, err
+	}
+	vsp.log.Info("CreateNetworkFunction(): Outport Veth", "OutportVeth", outportVeth)
+
+	err := vsp.vethUpAndAddToBridge(inportVeth)
+	if err != nil {
+		vsp.log.Error(err, "Error setting up inport Veth", "InportVeth", inportVeth.IfName)
+		return nil, err
+	}
+
+	err = vsp.vethUpAndAddToBridge(outportVeth)
+	if err != nil {
+		vsp.log.Error(err, "Error setting up outport Veth", "OutportVeth", outportVeth.IfName)
+		return nil, err
+	}
+
+	vsp.log.Info("CreateNetworkFunction(): Added Flow Rules to OvS Bridge", "InportVeth", inportVeth.IfName, "OutportVeth", outportVeth.IfName)
+	vsp.numNfs++
+	out := new(pb.Empty)
+	return out, nil
 }
 
 // TODO: Implement this
 func (vsp *intelNetSecVspServer) DeleteNetworkFunction(ctx context.Context, in *pb.NFRequest) (*pb.Empty, error) {
 	vsp.log.Info("Received DeleteNetworkFunction() request", "Input", in.Input, "Output", in.Output)
+
+	vsp.numNfs--
+
+	inportVeth, ok := vsp.vethTunnelPairDevs[vspnetutils.VethPairKey{IfMac: in.Input}]
+	if !ok {
+		err := fmt.Errorf("veth pair not found for input: %s", in.Input)
+		vsp.log.Error(err, "Error getting inport Veth", "InportVeth", in.Input)
+		return nil, err
+	}
+	vsp.log.Info("DeleteNetworkFunction(): Inport Veth", "InportVeth", inportVeth)
+
+	outportVeth, ok := vsp.vethTunnelPairDevs[vspnetutils.VethPairKey{IfMac: in.Output}]
+	if !ok {
+		err := fmt.Errorf("veth pair not found for output: %s", in.Output)
+		vsp.log.Error(err, "Error getting outport Veth", "OutportVeth", in.Output)
+		return nil, err
+	}
+	vsp.log.Info("DeleteNetworkFunction(): Outport Veth", "OutportVeth", outportVeth)
+
+	err := vspnetutils.DeleteInterfaceFromOvSBridge(OvSBridgeName, inportVeth.IfName)
+	if err != nil {
+		vsp.log.Error(err, "Error deleting interface from OvS Bridge", "InportVeth", inportVeth.IfName)
+		return nil, err
+	}
+	vsp.log.Info("DeleteNetworkFunction(): Deleted Interface from OvS Bridge", "InportVeth", inportVeth.IfName)
+
+	err = vspnetutils.DeleteInterfaceFromOvSBridge(OvSBridgeName, outportVeth.IfName)
+	if err != nil {
+		vsp.log.Error(err, "Error deleting interface from OvS Bridge", "OutportVeth", outportVeth.IfName)
+		return nil, err
+	}
+	vsp.log.Info("DeleteNetworkFunction(): Deleted Interface from OvS Bridge", "OutportVeth", outportVeth.IfName)
+
 	return nil, nil
 }
 
@@ -474,7 +669,7 @@ func (vsp *intelNetSecVspServer) setVlanIdsSpoofChk(numVfs int) error {
 	}
 
 	if len(ifNames) != 1 {
-		err = fmt.Errorf("expected exactly 1 interface for PCIe address %s, got %d", pcieAddr, len(ifNames))
+		err = fmt.Errorf("expected exactly 1 interface for PCIe address %s, got %v", pcieAddr, ifNames)
 		vsp.log.Error(err, "Error getting netdev name from PCIe address", "PCIeAddress", pcieAddr)
 		return err
 	}
@@ -563,6 +758,12 @@ func (vsp *intelNetSecVspServer) SetNumVfs(ctx context.Context, in *pb.VfCount) 
 		err = vspnetutils.SetSriovNumVfs(vsp.fs, IntelNetSecDpuBackplanef2PCIeAddress, int(in.VfCnt))
 		if err != nil {
 			vsp.log.Error(err, "Error setting number of VFs", "VfCnt", in.VfCnt, "PcieAddress", IntelNetSecDpuBackplanef2PCIeAddress)
+			return &pb.VfCount{VfCnt: 0}, err
+		}
+
+		err = vspnetutils.SetSriovNumVfs(vsp.fs, IntelNetSecDpuSFPf1PCIeAddress, MaxChains)
+		if err != nil {
+			vsp.log.Error(err, "Error occurred in setting number of VFs for SFP Port", "PCIeAddress", IntelNetSecDpuSFPf1PCIeAddress)
 			return &pb.VfCount{VfCnt: 0}, err
 		}
 	} else {
@@ -661,12 +862,15 @@ func NewIntelNetSecVspServer(opts ...func(*intelNetSecVspServer)) *intelNetSecVs
 	flag.Parse()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&options)))
 	vsp := &intelNetSecVspServer{
-		log:         ctrl.Log.WithName("IntelNetSecVsp"),
-		pathManager: *utils.NewPathManager("/"),
-		done:        make(chan error),
-		fs:          afero.NewOsFs(),
-		platform:    &platform.HardwarePlatform{},
-		vfDevs:      make(map[vspnetutils.VfDeviceKey]*vspnetutils.VfDeviceInfo),
+		log:                   ctrl.Log.WithName("IntelNetSecVsp"),
+		pathManager:           *utils.NewPathManager("/"),
+		done:                  make(chan error),
+		fs:                    afero.NewOsFs(),
+		platform:              &platform.HardwarePlatform{},
+		vfDevs:                make(map[vspnetutils.VfDeviceKey]*vspnetutils.VfDeviceInfo),
+		vethTunnelPairDevs:    make(map[vspnetutils.VethPairKey]*vspnetutils.VEthPairDeviceInfo),
+		numNfs:                0,
+		serviceFunctionChains: make(map[int]*intelNetSecServiceFunctionChain),
 	}
 
 	for _, opt := range opts {

--- a/internal/testutils/testcluster.go
+++ b/internal/testutils/testcluster.go
@@ -410,12 +410,11 @@ func DpuOperatorNamespace() *corev1.Namespace {
 	return namespace
 }
 
-func DpuOperatorCR(name string, mode string, ns *corev1.Namespace) *configv1.DpuOperatorConfig {
+func DpuOperatorCR(name string, ns *corev1.Namespace) *configv1.DpuOperatorConfig {
 	config := &configv1.DpuOperatorConfig{}
 	config.SetNamespace(ns.Name)
 	config.SetName(name)
 	config.Spec = configv1.DpuOperatorConfigSpec{
-		Mode:     mode,
 		LogLevel: 2,
 	}
 	return config

--- a/vendor/github.com/openshift/dpu-operator/api/v1/dpuoperatorconfig_types.go
+++ b/vendor/github.com/openshift/dpu-operator/api/v1/dpuoperatorconfig_types.go
@@ -27,10 +27,6 @@ import (
 
 // DpuOperatorConfigSpec defines the desired state of DpuOperatorConfig
 type DpuOperatorConfigSpec struct {
-	// Mode can be "host" or "dpu" and it defines on which side we are
-	// TODO: add support for auto
-	Mode string `json:"mode,omitempty"`
-
 	// Set log level of the operator. Edit dpuoperatorconfig_types.go to remove/update
 	LogLevel int `json:"logLevel,omitempty"`
 }

--- a/vendor/github.com/openshift/dpu-operator/api/v1/dpuoperatorconfig_webhook.go
+++ b/vendor/github.com/openshift/dpu-operator/api/v1/dpuoperatorconfig_webhook.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"context"
 	"fmt"
+
 	"github.com/openshift/dpu-operator/pkgs/vars"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -50,11 +51,6 @@ var _ webhook.CustomValidator = &DpuOperatorConfig{}
 func (r *DpuOperatorConfig) validateDpuOperatorConfig() (admission.Warnings, error) {
 	if r.Name != vars.DpuOperatorConfigName {
 		return nil, fmt.Errorf("DpuOperatorConfig must have standard name \"%s\"", vars.DpuOperatorConfigName)
-	}
-
-	mode := r.Spec.Mode
-	if mode != "host" && mode != "dpu" && mode != "auto" {
-		return nil, fmt.Errorf("Invalid mode")
 	}
 
 	return nil, nil


### PR DESCRIPTION
Remove Mode field for proper "auto" support

-  Remove the Mode field in the DPU Operator Config CRD because it is no longer needed when we auto detect whether each node is running with vs. on a DPU. This auto detection was completed in prior commits.
-  Remove all references to the Mode field in tests and code
- When creating NADs, we create both NADs for host and DPU
- This does not break existing setups since the auto detection code is in and the mode field is only used to control the creation of NADs.

Add support for Layer 3 Network Functions
    

- Revised VethPairs data structure to handle lookups by MAC address. This is needed since the API for creating network functions is by MAC address of the veth interface.
- To support Layer 3 Network Functions, the veth ports are simply connected to the OVS bridge. Pods on the host can reach other pods without going through the network function. However Pods on the host can reach the network function in the same subnet meaning that the network function must assign an IP address on the veth interfaces.
- Currently no OvS rules are needed to support Layer 3 Network Functions
