### PR TITLE
Cleanup pods before test

### DIFF
--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -339,8 +339,8 @@ var _ = g.Describe("E2E integration testing", g.Ordered, func() {
 			sfc = testutils.SfcNew(vars.Namespace, sfcName, nfName, imageRef)
 
 			// Clean up any existing test pods before creating new ones
-			testutils.EventuallyPodDoesNotExist(hostSideClient, testPodName, "default", testutils.TestAPITimeout*8, testutils.TestRetryInterval)
-			testutils.EventuallyPodDoesNotExist(hostSideClient, testPod2Name, "default", testutils.TestAPITimeout*8, testutils.TestRetryInterval)
+			testutils.DeleteAndEventuallyPodDoesNotExist(hostSideClient, testPodName, "default", testutils.TestAPITimeout*8, testutils.TestRetryInterval)
+			testutils.DeleteAndEventuallyPodDoesNotExist(hostSideClient, testPod2Name, "default", testutils.TestAPITimeout*8, testutils.TestRetryInterval)
 
 			nodeList, err := testutils.GetDPUNodes(hostSideClient)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Make tests more idempotent. If there are test pods already running, potentially from a previous failed test, clean those up before the new tests