### PR TITLE
Bump controller-gen to fix compatibilty with compiler

### DIFF
--- a/config/crd/bases/config.openshift.io_dataprocessingunits.yaml
+++ b/config/crd/bases/config.openshift.io_dataprocessingunits.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: dataprocessingunits.config.openshift.io
 spec:
   group: config.openshift.io
@@ -72,16 +72,8 @@ spec:
               conditions:
                 description: Status is the status of the DPU
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -122,12 +114,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/config/crd/bases/config.openshift.io_dpuoperatorconfigs.yaml
+++ b/config/crd/bases/config.openshift.io_dpuoperatorconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: dpuoperatorconfigs.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/crd/bases/config.openshift.io_servicefunctionchains.yaml
+++ b/config/crd/bases/config.openshift.io_servicefunctionchains.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: servicefunctionchains.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,41 +8,6 @@ rules:
   - ""
   resources:
   - '*'
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumeclaims
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumes
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
   - serviceaccounts
   verbs:
   - create
@@ -55,6 +20,10 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - persistentvolumeclaims
+  - persistentvolumes
+  - pods
+  - secrets
   - services
   verbs:
   - '*'
@@ -76,29 +45,7 @@ rules:
   - apps
   resources:
   - daemonsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
   - deployments
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
   - replicasets
   verbs:
   - create
@@ -112,69 +59,8 @@ rules:
   - config.openshift.io
   resources:
   - dataprocessingunits
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - dataprocessingunits/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - dataprocessingunits/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - config.openshift.io
-  resources:
   - dpuoperatorconfigs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - dpuoperatorconfigs/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - dpuoperatorconfigs/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - config.openshift.io
-  resources:
   - servicefunctionchains
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - config.openshift.io
-  resources:
   - servicefunctionchains/finalizers
   verbs:
   - create
@@ -187,6 +73,15 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - dataprocessingunits/finalizers
+  - dpuoperatorconfigs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - dataprocessingunits/status
+  - dpuoperatorconfigs/status
   - servicefunctionchains/status
   verbs:
   - get
@@ -208,41 +103,8 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
   - clusterroles
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
   - rolebindings
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
   - roles
   verbs:
   - create

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -20,7 +20,7 @@ vars:
   KUSTOMIZE_VERSION: v5.6.0
   GINKGO_VERSION:
     sh: go list -m -f '{{"{{.Version}}"}}' github.com/onsi/ginkgo/v2 | sed 's/^v//'
-  CONTROLLER_TOOLS_VERSION: v0.15.0
+  CONTROLLER_TOOLS_VERSION: v0.19.0
   SETUP_ENVTEST_VERSION: release-0.16
   OPERATOR_SDK_VERSION: v1.37.0
   OPM_VERSION: v1.23.0


### PR DESCRIPTION
Recently added prep step to ensure our CI's golang is as new as possible due to other dependencies moving forward. This revealed an issue with the controller-gen that was fixed in a newer version.