### PR TITLE
Spoofchk disable is needed for the external facing VF for PTL

### DIFF
--- a/cmd/daemon/daemon.go
+++ b/cmd/daemon/daemon.go
@@ -17,8 +17,6 @@ import (
 )
 
 func main() {
-	var mode string
-	flag.StringVar(&mode, "mode", "", "Mode for the daemon, can be either host or dpu")
 	opts := zap.Options{
 		Development: true,
 		Level:       zapcore.DebugLevel,
@@ -35,7 +33,7 @@ func main() {
 	nodeName := os.Getenv("K8S_NODE")
 
 	platform := &platform.HardwarePlatform{}
-	d := daemon.NewDaemon(afero.NewOsFs(), platform, mode, ctrl.GetConfigOrDie(), imageManager, utils.NewPathManager("/"), nodeName)
+	d := daemon.NewDaemon(afero.NewOsFs(), platform, ctrl.GetConfigOrDie(), imageManager, utils.NewPathManager("/"), nodeName)
 	if err := d.PrepareAndServe(context.Background()); err != nil {
 		log.Error(err, "Failed to run daemon")
 		panic(err)

--- a/internal/controller/bindata/daemon/99.daemonset.yaml
+++ b/internal/controller/bindata/daemon/99.daemonset.yaml
@@ -56,9 +56,6 @@ spec:
           mountPath: /proc
         - name: sys
           mountPath: /sys
-        args:
-        - --mode
-        - {{.Mode}}
       volumes:
         - name: devicesock
           hostPath:

--- a/internal/controller/dpuoperatorconfig_controller.go
+++ b/internal/controller/dpuoperatorconfig_controller.go
@@ -231,7 +231,6 @@ func (r *DpuOperatorConfigReconciler) yamlVars() map[string]string {
 	data := map[string]string{
 		"Namespace":       vars.Namespace,
 		"ImagePullPolicy": r.imagePullPolicy,
-		"Mode":            "auto",
 		"ResourceName":    "openshift.io/dpu", // FIXME: Hardcode for now
 		"CniDir":          p,
 	}

--- a/internal/controller/dpuoperatorconfig_controller_test.go
+++ b/internal/controller/dpuoperatorconfig_controller_test.go
@@ -144,7 +144,6 @@ var _ = Describe("Main Controller", Ordered, func() {
 			It("should have DPU daemon daemonsets created by controller manager", func() {
 				daemonSet := appsv1.DaemonSet{}
 				testutils.WaitForDaemonSetReady(&daemonSet, mgr.GetClient(), testNamespace, testDpuDaemonName)
-				Expect(daemonSet.Spec.Template.Spec.Containers[0].Args[1]).To(Equal("auto"))
 			})
 			It("should have the network function NAD created by controller manager", func() {
 				nad := &netattdefv1.NetworkAttachmentDefinition{}
@@ -176,10 +175,7 @@ var _ = Describe("Main Controller", Ordered, func() {
 			})
 			It("should have DPU daemon daemonsets created by controller manager", func() {
 				daemonSet := &appsv1.DaemonSet{}
-				Eventually(func() string {
-					testutils.WaitForDaemonSetReady(daemonSet, mgr.GetClient(), testNamespace, testDpuDaemonName)
-					return daemonSet.Spec.Template.Spec.Containers[0].Args[1]
-				}, testutils.TestAPITimeout*2, testutils.TestRetryInterval).Should(Equal("auto"))
+				testutils.WaitForDaemonSetReady(daemonSet, mgr.GetClient(), testNamespace, testDpuDaemonName)
 			})
 			It("should have the network function NAD created by controller manager", func() {
 				nad := &netattdefv1.NetworkAttachmentDefinition{}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -44,7 +44,6 @@ type ManagedDpu struct {
 }
 
 type Daemon struct {
-	mode              string
 	pm                *utils.PathManager
 	log               logr.Logger
 	imageManager      images.ImageManager
@@ -58,11 +57,10 @@ type Daemon struct {
 	nodeName          string
 }
 
-func NewDaemon(fs afero.Fs, p platform.Platform, mode string, config *rest.Config, imageManager images.ImageManager, pathManager *utils.PathManager, nodeName string) Daemon {
+func NewDaemon(fs afero.Fs, p platform.Platform, config *rest.Config, imageManager images.ImageManager, pathManager *utils.PathManager, nodeName string) Daemon {
 	log := ctrl.Log.WithName("Daemon")
 	return Daemon{
 		fs:                fs,
-		mode:              mode,
 		pm:                pathManager,
 		log:               log,
 		imageManager:      imageManager,

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -97,7 +97,7 @@ var _ = g.Describe("Full Daemon", func() {
 			}
 		}()
 
-		d = daemon.NewDaemon(fs, fakePlatform, "dpu", config, createVspTestImages(), pathManager, nodeName)
+		d = daemon.NewDaemon(fs, fakePlatform, config, createVspTestImages(), pathManager, nodeName)
 		go func() {
 			defer close(daemonDone)
 			err := d.PrepareAndServe(ctx)

--- a/internal/daemon/vendor-specific-plugins/intel-netsec/main.go
+++ b/internal/daemon/vendor-specific-plugins/intel-netsec/main.go
@@ -901,8 +901,6 @@ func WithPathManager(pathManager utils.PathManager) func(*intelNetSecVspServer) 
 }
 
 func NewIntelNetSecVspServer(opts ...func(*intelNetSecVspServer)) *intelNetSecVspServer {
-	var mode string
-	flag.StringVar(&mode, "mode", "", "Mode for the daemon, can be either host or dpu")
 	options := zap.Options{
 		Development: true,
 		Level:       zapcore.InfoLevel,

--- a/internal/daemon/vendor-specific-plugins/marvell/main.go
+++ b/internal/daemon/vendor-specific-plugins/marvell/main.go
@@ -790,8 +790,6 @@ func WithPathManager(pathManager utils.PathManager) func(*mrvlVspServer) {
 }
 
 func NewMarvellVspServer(opts ...func(*mrvlVspServer)) *mrvlVspServer {
-	var mode string
-	flag.StringVar(&mode, "mode", "", "Mode for the daemon, can be either host or dpu")
 	options := zap.Options{
 		Development: true,
 		Level:       zapcore.DebugLevel,


### PR DESCRIPTION
Packets are generated with the source MAC address of the internal veth interfaces in the network function. Hence we must disable spoof check because the external facing VF is intended to be used like a "switch port" connected to the OvS bridge.

Also remove some lingering auto mode code that can be safely removed.

