### PR TITLE
webhooks don't have namespace

### DIFF
--- a/internal/controller/bindata/network-resources-injector/01_webhook.yaml
+++ b/internal/controller/bindata/network-resources-injector/01_webhook.yaml
@@ -3,7 +3,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: network-resources-injector-config
-  namespace: {{.Namespace}}
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"
 webhooks:


### PR DESCRIPTION
This field was ignored in the past, but causes issues when adding owner ref chains