### PR TITLE
Handle the case where IPU takes a longer time to come up

### DIFF
--- a/hack/setup.sh
+++ b/hack/setup.sh
@@ -34,14 +34,15 @@ KUBECONFIG=/root/kubeconfig.microshift oc label nodes --all dpu=true
 KUBECONFIG=/root/kubeconfig.microshift oc create -f examples/config.yaml
 KUBECONFIG=/root/kubeconfig.ocpcluster oc create -f examples/config.yaml
 
-# Wait for DpuOperatorConfig to be Ready on both clusters
-echo "Waiting for DpuOperatorConfig to be Ready on microshift cluster..."
-KUBECONFIG=/root/kubeconfig.microshift oc wait --for=condition=Ready dpuoperatorconfig/dpu-operator-config -n openshift-dpu-operator --timeout=1m
 echo "Waiting for DpuOperatorConfig to be Ready on OCP cluster..."
 KUBECONFIG=/root/kubeconfig.ocpcluster oc wait --for=condition=Ready dpuoperatorconfig/dpu-operator-config -n openshift-dpu-operator --timeout=1m
-
-wait_for_dpu /root/kubeconfig.microshift
+echo "Waiting for DPU to be Ready on OCP cluster..."
 wait_for_dpu /root/kubeconfig.ocpcluster
+
+echo "Waiting for DpuOperatorConfig to be Ready on microshift cluster..."
+KUBECONFIG=/root/kubeconfig.microshift oc wait --for=condition=Ready dpuoperatorconfig/dpu-operator-config -n openshift-dpu-operator --timeout=1m
+echo "Waiting for DPU to be Ready on microshift cluster..."
+wait_for_dpu /root/kubeconfig.microshift
 
 KUBECONFIG=/root/kubeconfig.ocpcluster oc wait --for=condition=Ready pod --all -n openshift-dpu-operator --timeout=5m
 KUBECONFIG=/root/kubeconfig.microshift oc wait --for=condition=Ready pod --all -n openshift-dpu-operator --timeout=5m


### PR DESCRIPTION
Edge case when ipu reboots that wait will fail since microshift will go down. Instead, wait on the host side, and then wait for the DPU side. If the host is ready, the DPU should be too.

This edge case will be better taken care of when we add IIC-960. That will only allow the host side DPU CR to go into ready state if the DPU responded to at least 1 health probe which it will only do if the init on the dpu also succeeded.