### PR TITLE
[th/marvell-veth-no-offload] marvell: disable tx/rx hardware offload on veth pairs

### DIFF
--- a/Dockerfile.mrvlVSP.rhel
+++ b/Dockerfile.mrvlVSP.rhel
@@ -29,6 +29,7 @@ RUN yum update -y \
        pciutils \
        iputils \
        iproute \
+       ethtool \
     && yum clean all \
     && rm -rf /var/cache/dnf
 


### PR DESCRIPTION
As we have veth interfaces, there is no "hardware" to offload to. Instead, we attacht those interfaces to OVS. The veth pair then sends incomplete packets without a checksum, and OVS doesn't fill them in either. The result is a broken checksum and broken TCP.

Fix that by disabling hardware offloading for "tx" and "rx".

https://issues.redhat.com/browse/MDC-122
See-also: https://arthurchiao.art/blog/ovs-deep-dive-5-datapath-tx-offloading/