### PR TITLE
e2e-test: honor EXTERNAL_CLIENT_DEV environment variable

### DIFF
--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -165,7 +165,7 @@ tasks:
         FAST_TEST=true
         REGISTRY={{.REGISTRY}}
         NF_INGRESS_IP=10.20.30.2
-        EXTERNAL_CLIENT_DEV=eno12409
+        EXTERNAL_CLIENT_DEV="${EXTERNAL_CLIENT_DEV:-eno12409}"
         EXTERNAL_CLIENT_IP=10.20.30.100
         KUBEBUILDER_ASSETS="$({{.BINDIR}}/setup-envtest use {{.ENVTEST_K8S_VERSION}} --bin-dir {{.BINDIR_ABS}} -p path)"
         {{.BINDIR}}/ginkgo -coverprofile cover.out ./e2e_test/...


### PR DESCRIPTION
`task e2e-test` only works in certain clusters configured for Red Hat CI. External users can technically run it on their own clusters, but this requires either patching sources or providing access to a Google spreadsheet ("ANL lab HW enablement clusters and connections"). Since the spreadsheet layout is undocumented and fragile, external users almost always end up patching sources.

Previously, the provisioning host’s external interface was hardcoded as "eno12409". This was inaccurate even for some internal clusters (e.g., on some Marvell clusters it is "eno2"). To avoid hardcoding, make the value overridable via the EXTERNAL_CLIENT_DEV environment variable. Marvell’s Jenkins CI job already sets this accordingly.

Note: CDA’s `clusterInfo.py` can extract the correct interface from the spreadsheet (via the `secondary_network_port` attribute):

    python ./cluster-deployment-automation/clusterInfo.py host

However, dpu-operator does not query clusterInfo directly, so we rely on the caller to set EXTERNAL_CLIENT_DEV. Either explicitly or even via:

    export EXTERNAL_CLIENT_DEV="$(python ./cluster-deployment-automation/clusterInfo.py host \
      | jq -r '.secondary_network_port')"

This is necessary to make come CI tests on the marvell cluster pass, which currently are skipped by letting Jenkins set SKIP_NF_TESTING=1.