### PR TITLE
Expose build-bin-all

### DIFF
--- a/taskfiles/binaries.yaml
+++ b/taskfiles/binaries.yaml
@@ -37,3 +37,12 @@ tasks:
       GOARCH: '{{.GOARCH}}'
     cmds:
       - GOOS={{.GOOS}} GOARCH={{.GOARCH}} go build -o {{.BINDIR}}/nri.{{.GOARCH}} cmd/nri/networkresourcesinjector.go
+
+  build-bin-all:
+    deps:
+      - build-bin-manager
+      - build-bin-daemon
+      - build-bin-intel-vsp
+      - build-bin-marvell-vsp
+      - build-bin-intel-netsec-vsp
+      - build-bin-network-resources-injector

--- a/taskfiles/images.yaml
+++ b/taskfiles/images.yaml
@@ -358,12 +358,7 @@ tasks:
     # build all the binaries in parallel for speed
     # they will be picked up by the build-image-* targets
     deps:
-      - build-bin-manager
-      - build-bin-daemon
-      - build-bin-intel-vsp
-      - build-bin-marvell-vsp
-      - build-bin-intel-netsec-vsp
-      - build-bin-network-resources-injector
+      - build-bin-all
     cmds: # can't run in parallel since multiple concurrent pulls are not supported 
       - task: build-image-manager
       - task: build-image-daemon


### PR DESCRIPTION
Self explanatory. Makes it easier for AI to know if it made a mistake by building all bins in 1 shot.