### PR TITLE
Refactor 2 cluster in E2E tests and add 1 cluster support

### DIFF
--- a/hack/cluster-configs/config-1-cluster.yaml
+++ b/hack/cluster-configs/config-1-cluster.yaml
@@ -33,7 +33,7 @@ clusters:
         user: "root"
         password: "calvin"
         url: "{{bmc(0)}}"
-    - name: "worker-{{worker_number(1)}}"
+    - name: "worker-dpu-{{worker_number(1)}}"
       kind: "physical"
       node: "{{worker_name(1)}}" 
       bmc:

--- a/hack/cluster-configs/ocp-tft-config.yaml
+++ b/hack/cluster-configs/ocp-tft-config.yaml
@@ -19,4 +19,3 @@ tft:
             sriov: "true"
         secondary_network_nad: "default-sriov-net"
 kubeconfig: "/root/kubeconfig.ocpcluster"
-kubeconfig_infra: "/root/kubeconfig.microshift"

--- a/hack/traffic_flow_tests.sh
+++ b/hack/traffic_flow_tests.sh
@@ -15,14 +15,6 @@ if [ -z "$worker" ]; then
   exit 1
 fi
 
-export KUBECONFIG=/root/kubeconfig.microshift
-nodes=$(oc get nodes)
-export acc=$(echo "$nodes" | grep -oP '^\d+-acc')
-if [ -z "$acc" ]; then
-  echo "Error: acc is empty"
-  exit 1
-fi
-
 temp_file=$(mktemp)
 
 envsubst < ../hack/cluster-configs/ocp-tft-config.yaml > $temp_file

--- a/internal/testutils/cdacluster.go
+++ b/internal/testutils/cdacluster.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"fmt"
 	"os"
 
 	"k8s.io/client-go/rest"
@@ -8,21 +9,13 @@ import (
 )
 
 type CdaCluster struct {
-	Name           string
-	HostConfigPath string
-	DpuConfigPath  string
 }
 
-func (t *CdaCluster) EnsureExists() (*rest.Config, *rest.Config, error) {
-	hostConfig, err := t.createClient("/root/kubeconfig.ocpcluster")
-	if err != nil {
-		return nil, nil, err
+func (t *CdaCluster) EnsureExists(kubeconfigPath string) (*rest.Config, error) {
+	if _, err := os.Stat(kubeconfigPath); err == nil {
+		return t.createClient(kubeconfigPath)
 	}
-	dpuConfig, err := t.createClient("/root/kubeconfig.microshift")
-	if err != nil {
-		return nil, nil, err
-	}
-	return hostConfig, dpuConfig, nil
+	return nil, fmt.Errorf("kubeconfig %s not found", kubeconfigPath)
 }
 
 func (t *CdaCluster) createClient(kubeconfigPath string) (*rest.Config, error) {

--- a/internal/testutils/testcluster.go
+++ b/internal/testutils/testcluster.go
@@ -97,9 +97,21 @@ func ExecInPod(clientset kubernetes.Interface, config *rest.Config, pod *corev1.
 	return stdout.String(), nil
 }
 
+func GetDPUHostNodes(c client.Client) ([]corev1.Node, error) {
+	nodeList := &corev1.NodeList{}
+	labelSelector := client.MatchingLabels{"dpu.config.openshift.io/dpuside": "dpu-host"}
+
+	err := c.List(context.TODO(), nodeList, labelSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	return nodeList.Items, nil
+}
+
 func GetDPUNodes(c client.Client) ([]corev1.Node, error) {
 	nodeList := &corev1.NodeList{}
-	labelSelector := client.MatchingLabels{"dpu": "true"}
+	labelSelector := client.MatchingLabels{"dpu.config.openshift.io/dpuside": "dpu"}
 
 	err := c.List(context.TODO(), nodeList, labelSelector)
 	if err != nil {

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -170,6 +170,8 @@ tasks:
     cmds:
       - >
         FAST_TEST=true
+        KUBECONFIG_HOST={{.KUBECONFIG_HOST}}
+        KUBECONFIG_DPU={{.KUBECONFIG_DPU}}
         REGISTRY={{.REGISTRY}}
         NF_INGRESS_IP=10.20.30.2
         EXTERNAL_CLIENT_DEV=eno12409


### PR DESCRIPTION
The current e2e tests assumes 2 clusters. Depending on which kubeconfigs exists we should detect whether it is in 2 cluster or 1 cluster modes. Once the 2 vs 1 cluster deployment is determined, there are code changes to make sure the tests work in either approach.
