### PR TITLE
WIP: Add ready handler

### DIFF
--- a/internal/controller/bindata/daemon/99.daemonset.yaml
+++ b/internal/controller/bindata/daemon/99.daemonset.yaml
@@ -27,6 +27,14 @@ spec:
         securityContext:
           privileged: true
         imagePullPolicy: {{.ImagePullPolicy}}
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          timeoutSeconds: 1
+          failureThreshold: 2
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
By ensuring that we run at least one detection cycle, any DPU CRs that should be synced will be synced before we move the the DPU Operator Config CR to ready state. That way, there is not sleep needed in any automation that sets up the operator and waits for the DPUs to be available between waiting for the operator config to move to ready state and waiting for the first DPU CR to be available. We also call the daemon "not ready" as long as it's not really up (i.e. it's running the detection cycles).

The main intent is to remove a tricky place where race conditions could occur with anything that interacts with the DPU Operator.