### PR TITLE
[th/art-image-refs] manifest: uncomment image-references to use ART images

### DIFF
--- a/manifests/stable/image-references
+++ b/manifests/stable/image-references
@@ -11,13 +11,10 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/dpu-daemon:latest
-  # The following images don't exist yet. For now, comment them out to
-  # not break the build.
-  # https://github.com/openshift-eng/art-tools/blob/ade5d7adf6b3fb4094f25cdd5dfce96453eb103d/doozer/doozerlib/backend/rebaser.py#L2033
-  #- name: dpu-network-resources-injector
-  #  from:
-  #    kind: DockerImage
-  #    name: quay.io/openshift/dpu-network-resources-injector:latest
+  - name: dpu-network-resources-injector
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/dpu-network-resources-injector:latest
   - name: dpu-intel-ipu-vsp
     from:
       kind: DockerImage
@@ -26,15 +23,15 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/dpu-intel-ipu-p4sdk:latest
-  #- name: dpu-marvell-vsp
-  #  from:
-  #    kind: DockerImage
-  #    name: quay.io/openshift/dpu-marvell-vsp:latest
-  #- name: dpu-marvell-cp-agent
-  #  from:
-  #    kind: DockerImage
-  #    name: quay.io/openshift/dpu-marvell-cp-agent:latest
-  #- name: dpu-intel-netsec-vsp
-  #  from:
-  #    kind: DockerImage
-  #    name: quay.io/openshift/dpu-intel-netsec-vsp:latest
+  - name: dpu-marvell-vsp
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/dpu-marvell-vsp:latest
+  - name: dpu-marvell-cp-agent
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/dpu-marvell-cp-agent:latest
+  - name: dpu-intel-netsec-vsp
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/dpu-intel-netsec-vsp:latest


### PR DESCRIPTION
The ART build tooling uses this file to patch the manifest file. See the script at [1].

We failed to properly onboard various images in ART. This is now in the process of being fixed with [2].

Uncomment the image-references to make use of the ART images that are now being built.

[1] https://github.com/openshift-eng/art-tools/blob/99cda969e7fec2e34b35b1cd393dc6c72f3c0ae4/doozer/doozerlib/backend/rebaser.py#L2065
[2] https://issues.redhat.com/browse/NHE-1571