### PR TITLE
Fix up various flakiness in Race Conditions and Improper Handling

### DIFF
--- a/dpu-cni/pkgs/sriov/sriov.go
+++ b/dpu-cni/pkgs/sriov/sriov.go
@@ -55,7 +55,7 @@ type Manager interface {
 	ApplyVFConfig(conf *cnitypes.NetConf) error
 	FillOriginalVfInfo(conf *cnitypes.NetConf) error
 	CmdAdd(req *cnitypes.PodRequest) (*current.Result, error)
-	CmdDel(req *cnitypes.PodRequest) error
+	CmdDel(req *cnitypes.PodRequest) (bool, error)
 }
 
 type sriovManager struct {
@@ -504,7 +504,10 @@ func (sm *sriovManager) CmdAdd(req *cnitypes.PodRequest) (*current.Result, error
 	return result, nil
 }
 
-func (sm *sriovManager) CmdDel(req *cnitypes.PodRequest) error {
+// CmdDel removes the device from the host. Plumbing of the DPU is done outside this function..
+// Returns true if the VF is released, meaning that plumbing must be done on the DPU side
+// Returns false if the VF is not released, meaning that plumbing should be avoided on the DPU side.
+func (sm *sriovManager) CmdDel(req *cnitypes.PodRequest) (bool, error) {
 	klog.Info("CmdDel called")
 
 	netConf, cRefPath, err := sriovconfig.LoadConfFromCache(req.ContainerId, req.IfName)
@@ -516,8 +519,10 @@ func (sm *sriovManager) CmdDel(req *cnitypes.PodRequest) error {
 		// Return nil when LoadConfFromCache fails since the rest
 		// of cmdDel() code relies on netconf as input argument
 		// and there is no meaning to continue.
+		// This can happen if the cmdAdd failed, but was before the netconfg was cached.
+		// Meaning that the VF was not setup in the container and reverted.
 		klog.Errorf("Cannot load config file from cache %v", err)
-		return nil
+		return false, nil
 	}
 
 	defer func() {
@@ -527,28 +532,30 @@ func (sm *sriovManager) CmdDel(req *cnitypes.PodRequest) error {
 	}()
 
 	if netConf.IPAM.Type != "" {
+		klog.Infof("CmdDel(): Executing IPAM plugin. IPAM type: %s", netConf.IPAM.Type)
 		err = ipam.ExecDel(netConf.IPAM.Type, req.CNIReq.Config)
 		if err != nil {
-			return err
+			return false, err
 		}
 	}
 
 	// https://github.com/kubernetes/kubernetes/pull/35240
 	if req.Netns == "" {
-		return nil
+		return false, nil
 	}
 
 	// Verify VF ID existence.
 	if _, err := sriovutils.GetVfid(netConf.DeviceID, netConf.Master); err != nil {
-		return fmt.Errorf("cmdDel() error obtaining VF ID: %q", err)
+		return false, fmt.Errorf("cmdDel() error obtaining VF ID: %q", err)
 	}
 
+	klog.Infof("CmdDel(): Reset VF configuration %s", netConf.DeviceID)
 	/* ResetVFConfig resets a VF administratively. We must run ResetVFConfig
 	   before ReleaseVF because some drivers will error out if we try to
 	   reset netdev VF with trust off. So, reset VF MAC address via PF first.
 	*/
 	if err := sm.ResetVFConfig(netConf); err != nil {
-		return fmt.Errorf("cmdDel() error reseting VF: %q", err)
+		return false, fmt.Errorf("cmdDel() error reseting VF: %q", err)
 	}
 
 	if !netConf.DPDKMode {
@@ -561,15 +568,17 @@ func (sm *sriovManager) CmdDel(req *cnitypes.PodRequest) error {
 			// IPAM resources
 			_, ok := err.(ns.NSPathNotExistErr)
 			if ok {
-				return nil
+				klog.Infof("cmdDel(): Exiting as the network namespace does not exists anymore %s", netConf.DeviceID)
+				return false, nil
 			}
 
-			return fmt.Errorf("failed to open netns %s: %q", netns, err)
+			return false, fmt.Errorf("failed to open netns %s: %q", netns, err)
 		}
 		defer netns.Close()
 
+		klog.Infof("cmdDel(): Release the VF Device ID %s, NetNS %s IfName %s", netConf.DeviceID, req.Netns, req.IfName)
 		if err = sm.ReleaseVF(netConf, req.IfName, netns); err != nil {
-			return err
+			return false, err
 		}
 	}
 	req.CNIConf.VFID = netConf.VFID
@@ -577,8 +586,8 @@ func (sm *sriovManager) CmdDel(req *cnitypes.PodRequest) error {
 	// Mark the pci address as released
 	klog.Infof("Mark the PCI address as released %s %s", sriovconfig.DefaultCNIDir, netConf.DeviceID)
 	if err = sm.allocator.DeleteAllocatedPCI(netConf.DeviceID); err != nil {
-		return fmt.Errorf("error cleaning the pci allocation for vf pci address %s: %v", netConf.DeviceID, err)
+		return false, fmt.Errorf("error cleaning the pci allocation for vf pci address %s: %v", netConf.DeviceID, err)
 	}
 
-	return nil
+	return true, nil
 }

--- a/internal/daemon/dpusidemanager.go
+++ b/internal/daemon/dpusidemanager.go
@@ -75,7 +75,7 @@ func (s *DpuSideManager) getPing() time.Time {
 }
 
 func (s *DpuSideManager) Ping(ctx context.Context, req *pb2.PingRequest) (*pb2.PingResponse, error) {
-	s.log.V(1).Info("Received heartbeat ping", "from", req.SenderId, "timestamp", req.Timestamp)
+	s.log.V(2).Info("Received heartbeat ping", "from", req.SenderId, "timestamp", req.Timestamp)
 
 	// Record the time we received this ping
 	s.setPing(time.Now())

--- a/internal/daemon/hostsidemanager.go
+++ b/internal/daemon/hostsidemanager.go
@@ -207,17 +207,19 @@ func (d *HostSideManager) cniCmdAddHandler(req *cnitypes.PodRequest) (*cni100.Re
 }
 
 func (d *HostSideManager) cniCmdDelHandler(req *cnitypes.PodRequest) (*cni100.Result, error) {
-	err := d.sm.CmdDel(req)
+	vfReleased, err := d.sm.CmdDel(req)
 	if err != nil {
 		return nil, errors.New("SRIOV manager failed in del handler")
 	}
-	pf := 0
-	vf := req.CNIConf.VFID
-	mac := req.CNIConf.OrigVfState.EffectiveMAC
-	// TODO: fix setting Vlan based on network definition in CR
-	vlan := 2 // *req.CNIConf.Vlan
-	d.log.Info("delHandler", "pf", pf, "vf", vf, "mac", mac, "vlan", vlan)
-	d.DeleteBridgePort(pf, vf, vlan, mac)
+	if vfReleased {
+		pf := 0
+		vf := req.CNIConf.VFID
+		mac := req.CNIConf.OrigVfState.EffectiveMAC
+		// TODO: fix setting Vlan based on network definition in CR
+		vlan := 2 // *req.CNIConf.Vlan
+		d.log.Info("cniCmdDelHandler", "pf", pf, "vf", vf, "mac", mac, "vlan", vlan)
+		d.DeleteBridgePort(pf, vf, vlan, mac)
+	}
 	return nil, nil
 }
 

--- a/internal/daemon/hostsidemanager.go
+++ b/internal/daemon/hostsidemanager.go
@@ -264,7 +264,7 @@ func (d *HostSideManager) Ping() bool {
 	// Record successful ping
 	d.setPing(time.Now())
 
-	d.log.V(1).Info("Ping successful")
+	d.log.V(2).Info("Ping successful")
 	return true
 }
 

--- a/internal/daemon/hostsidemanager_test.go
+++ b/internal/daemon/hostsidemanager_test.go
@@ -99,8 +99,8 @@ func (m SriovManagerStub) CmdAdd(req *cnitypes.PodRequest) (*current.Result, err
 	return result, nil
 }
 
-func (m SriovManagerStub) CmdDel(req *cnitypes.PodRequest) error {
-	return nil
+func (m SriovManagerStub) CmdDel(req *cnitypes.PodRequest) (bool, error) {
+	return false, nil
 }
 
 type DummyDpuDaemon struct {

--- a/internal/daemon/vendor-specific-plugins/intel-netsec/main.go
+++ b/internal/daemon/vendor-specific-plugins/intel-netsec/main.go
@@ -491,7 +491,7 @@ func (vsp *intelNetSecVspServer) DeleteBridgePort(ctx context.Context, in *opi.D
 
 	err = vspnetutils.DeleteInterfaceFromOvSBridge(OvSBridgeName, vfIfName)
 	if err != nil {
-		vsp.log.Error(err, "Error adding VF to OvS Bridge", "BridgePortName", in.Name, "vfIfName", vfIfName)
+		vsp.log.Error(err, "Error deleting VF to OvS Bridge", "BridgePortName", in.Name, "vfIfName", vfIfName)
 		return nil, err
 	}
 
@@ -602,19 +602,19 @@ func (vsp *intelNetSecVspServer) DeleteNetworkFunction(ctx context.Context, in *
 	}
 	vsp.log.Info("DeleteNetworkFunction(): Outport Veth", "OutportVeth", outportVeth)
 
-	err := vspnetutils.DeleteInterfaceFromOvSBridge(OvSBridgeName, inportVeth.IfName)
+	err := vspnetutils.DeleteInterfaceFromOvSBridge(OvSBridgeName, inportVeth.PeerName)
 	if err != nil {
-		vsp.log.Error(err, "Error deleting interface from OvS Bridge", "InportVeth", inportVeth.IfName)
+		vsp.log.Error(err, "Error deleting interface from OvS Bridge", "InportVeth", inportVeth.PeerName)
 		return nil, err
 	}
-	vsp.log.Info("DeleteNetworkFunction(): Deleted Interface from OvS Bridge", "InportVeth", inportVeth.IfName)
+	vsp.log.Info("DeleteNetworkFunction(): Deleted Interface from OvS Bridge", "InportVeth", inportVeth.PeerName)
 
-	err = vspnetutils.DeleteInterfaceFromOvSBridge(OvSBridgeName, outportVeth.IfName)
+	err = vspnetutils.DeleteInterfaceFromOvSBridge(OvSBridgeName, outportVeth.PeerName)
 	if err != nil {
-		vsp.log.Error(err, "Error deleting interface from OvS Bridge", "OutportVeth", outportVeth.IfName)
+		vsp.log.Error(err, "Error deleting interface from OvS Bridge", "OutportVeth", outportVeth.PeerName)
 		return nil, err
 	}
-	vsp.log.Info("DeleteNetworkFunction(): Deleted Interface from OvS Bridge", "OutportVeth", outportVeth.IfName)
+	vsp.log.Info("DeleteNetworkFunction(): Deleted Interface from OvS Bridge", "OutportVeth", outportVeth.PeerName)
 
 	return nil, nil
 }


### PR DESCRIPTION
Add locking for CmdAdd & CmdDel & move setting ENV varibles for IPAM
    
Since CmdAdd & CmdDel can be invoked multiple times by kubelet or container runtime. We want to prevent CmdAdd or CmdDel to run on the same VF device that is still being handled by CmdDel instance. For now, we will use a global lock (different approach from SR-IOV CNI). However, this lock solves another issue of CNIs in general which is the use of OS environment variables (globals)
    
Since ENV variables are process wide variables we need to move them into CmdAdd and CmdDel for IPAM otherwise we can get into race conditions when calling the IPAM plugin. Additionally CmdAdd + CmdDel needs a mutual exclusion lock consequently.

Fix Issue where CmdDel occurs on a VF that was not plumbed on the DPU

CmdDel can be called when CmdAdd fails; however if CmdAdd failed and the netconf is not cached then the subsequent CmdDel would not be able to find the non-existent cache. This is ok because the CmdAdd would have been able to properly cleanup before returning.

The issue is that if CmdDel continues to call DeleteBridgePort, the DPU would get an nonsense request. We shouldn't propagate DeleteBridgePort when CreateBridgePort would have never executed due to CmdAdd failing.

Fix deletion of VETH pair for Network Function
    
In DeleteBridgePort, the wrong side of the VETH was being deleted from the OvS bridge.