### PR TITLE
OCPBUGS-75754: Update Go version to 1.24.12 to fix CVE-2025-61726

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/dpu-operator
 
-go 1.24.3
+go 1.24.12
 
 require (
 	github.com/containernetworking/cni v1.2.3


### PR DESCRIPTION
This addresses CVE-2025-61726 (memory exhaustion in net/url query parameter parsing) by updating from Go 1.24.3 to 1.24.12.

Fixes: OCPBUGS-75754