### PR TITLE
OCPBUGS-81739: Update Go to 1.24.12 to fix CVE-2025-61726

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/dpu-operator
 
-go 1.24.3
+go 1.24.12
 
 require (
 	github.com/containernetworking/cni v1.2.3


### PR DESCRIPTION
## Description

Backport of fix for **CVE-2025-61726** (memory exhaustion in `net/url` query parameter parsing) to `release-4.21`.

Bumps the minimum Go version from `1.24.3` to `1.24.12` in `go.mod`. The `net/url` package did not limit the number of query parameters, allowing excessive memory consumption via `ParseForm()` with large URL-encoded forms. Go 1.24.12 includes the fix.

The same fix was previously merged to `main` via #642, but `main` targets 4.22. This PR applies the fix to the correct branch for 4.21.

## Jira

- https://redhat.atlassian.net/browse/OCPBUGS-81739

## Cherry-pick

Cherry-picked from commit `8698cecc` (PR #642).