### PR TITLE
fix: revert CGO_ENABLED=0 for arm64 cross-compilation in all Dockerfiles

### DIFF
--- a/Dockerfile.IntelVSP.rhel
+++ b/Dockerfile.IntelVSP.rhel
@@ -7,7 +7,7 @@ COPY . .
 
 # Due to https://github.com/golang/go/issues/70329 cross-compilation hangs at times.
 # As a temporary workaround, we can try specifying GOMAXPROCS=2 to relieve this issue
-RUN GOMAXPROCS=2 CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} make build-intel-vsp
+RUN GOMAXPROCS=2 CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} make build-intel-vsp
 
 FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 ARG TARGETARCH

--- a/Dockerfile.daemon.rhel
+++ b/Dockerfile.daemon.rhel
@@ -14,7 +14,7 @@ COPY . .
 
 # Due to https://github.com/golang/go/issues/70329 cross-compilation hangs at times.
 # As a temporary workaround, we can try specifying GOMAXPROCS=2 to relieve this issue
-RUN GOMAXPROCS=2 CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} make build-daemon
+RUN GOMAXPROCS=2 CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} make build-daemon
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.mrvlCPAgent.rhel
+++ b/Dockerfile.mrvlCPAgent.rhel
@@ -54,7 +54,7 @@ RUN \
 # As a temporary workaround, we can try specifying GOMAXPROCS=2 to relieve this issue
 
 WORKDIR /workspace
-RUN GOMAXPROCS=2 CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o /cpagent-bin/cp-agent-run internal/daemon/vendor-specific-plugins/marvell/cp-agent/cp-agent-run.go
+RUN GOMAXPROCS=2 CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o /cpagent-bin/cp-agent-run internal/daemon/vendor-specific-plugins/marvell/cp-agent/cp-agent-run.go
 
 # Use distroless as minimal base image to package the Marvell CP agent binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.networkResourcesInjector.rhel
+++ b/Dockerfile.networkResourcesInjector.rhel
@@ -3,7 +3,7 @@ ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /workspace
 COPY . .
-RUN GOMAXPROCS=2 CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} make build-network-resources-injector
+RUN GOMAXPROCS=2 CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} make build-network-resources-injector
 
 FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 ARG TARGETARCH

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -14,7 +14,7 @@ COPY . .
 
 # Due to https://github.com/golang/go/issues/70329 cross-compilation hangs at times.
 # As a temporary workaround, we can try specifying GOMAXPROCS=2 to relieve this issue
-RUN GOMAXPROCS=2 CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} make build-manager
+RUN GOMAXPROCS=2 CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} make build-manager
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
## Problem

Commit `1e03612b` changed `CGO_ENABLED=0` to `CGO_ENABLED=1` in all Dockerfiles. This breaks arm64 cross-compilation on x86 build hosts:

- The builder image (`registry.ci.openshift.org/ocp/builder`) is x86-only with no arm64 variant
- `CGO_ENABLED=1 GOARCH=arm64` on x86 requires an ARM64 C compiler to compile Go runtime CGO code (`gcc_arm64.S` from `$GOROOT/src/runtime/cgo/`)
- No ARM64 cross-compiler (`aarch64-linux-gnu-gcc`) is present in the builder container image
- None of the binaries built here actually use CGO (no `import "C"` in any of the build targets)

## Fix

Revert `CGO_ENABLED=1` back to `CGO_ENABLED=0`. This restores the previous behavior where Go cross-compiles to arm64 natively without any C compiler dependency.

## Testing

Verified the fix locally in the Jenkins CI workspace — the arm64 build proceeds past the `gcc_arm64.S` failure with `CGO_ENABLED=0`.