### PR TITLE
Bump CSV version from 4.21.0 to 4.23.0 on release-4.23

### DIFF
--- a/manifests/stable/dpu-operator.clusterserviceversion.yaml
+++ b/manifests/stable/dpu-operator.clusterserviceversion.yaml
@@ -86,7 +86,7 @@ metadata:
     operatorframework.io/suggested-namespace: openshift-dpu-operator
     operators.operatorframework.io/builder: operator-sdk-v1.41.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: dpu-operator.v4.21.0
+  name: dpu-operator.v4.23.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -423,7 +423,7 @@ spec:
   provider:
     name: Red Hat
     url: www.redhat.com
-  version: 4.21.0
+  version: 4.23.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1


### PR DESCRIPTION
The ClusterServiceVersion was not updated when the release-4.23 branch was created from release-4.21, causing ART/doozer rebase failures: "Search 'dpu-operator.v4.23.0' and replace was ineffective"

Ref: [OCPBUGS-88504](https://redhat.atlassian.net/browse/OCPBUGS-88504)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED