### PR TITLE
OCPBUGS-99741: Bump CSV version from 4.21.0 to 4.22.0

### DIFF
--- a/manifests/dpu-operator.package.yaml
+++ b/manifests/dpu-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: dpu-operator
 channels:
 - name: "stable"
-  currentCSV: dpu-operator.v4.21.0
+  currentCSV: dpu-operator.v4.22.0

--- a/manifests/stable/dpu-operator.clusterserviceversion.yaml
+++ b/manifests/stable/dpu-operator.clusterserviceversion.yaml
@@ -86,7 +86,7 @@ metadata:
     operatorframework.io/suggested-namespace: openshift-dpu-operator
     operators.operatorframework.io/builder: operator-sdk-v1.41.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: dpu-operator.v4.21.0
+  name: dpu-operator.v4.22.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -423,7 +423,7 @@ spec:
   provider:
     name: Red Hat
     url: www.redhat.com
-  version: 4.21.0
+  version: 4.22.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1


### PR DESCRIPTION
  CSV metadata.name, spec.version, and package.yaml currentCSV still had
  4.21.0 on the release-4.22 branch. This causes ART's art.yaml
  search-and-replace to silently fail because it searches for v4.22.0
  patterns that don't exist in the source.

  Fixes: OCPBUGS-99741

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED